### PR TITLE
Add HED annotations support (v0.2.0-beta)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ frontend/public/*
 !frontend/public/favicon.ico
 !frontend/public/image-list.json
 !frontend/public/copy-static-assets.sh
+!frontend/public/human-hed.json
 
 # Image files (but keep README, and downsampled)
 images/original/*.png

--- a/annotations/nsd/shared0001_nsd02951_annotations.json
+++ b/annotations/nsd/shared0001_nsd02951_annotations.json
@@ -32,6 +32,7 @@
           "response_format": "text",
           "response_data": null,
           "error": null,
+          "hed_annotation": "Sensory-event, Experimental-stimulus, Visual-presentation, (Item/Carrot, Large, Property/Foreground, Property/Neatly-stacked, Property/Dominating), (Item/Umbrella), (Item/Hat), (Item/Headscarf), (Item/Stall), (Item/Market), (Item/Outdoor), Property/Bright-lighting, Property/Clear-sky, Property/Soft-shadows, Agent-action, ((Agent/Vendor), (Action/Selling, (Item/Carrot))), Agent-action, ((Agent/Customer), (Action/Browsing, (Item/Carrot))), Agent-action, ((Agent/Vendor), (Action/Arranging, (Item/Carrot)))",
           "token_metrics": {
             "input_tokens": 297,
             "output_tokens": 211,

--- a/frontend/app/components/AnnotationViewer.tsx
+++ b/frontend/app/components/AnnotationViewer.tsx
@@ -13,6 +13,15 @@ export default function AnnotationViewer({ annotation, platform }: AnnotationVie
   const [copied, setCopied] = useState(false)
   const [viewMode, setViewMode] = useState<'text' | 'json'>('text')
   const [hedExpanded, setHedExpanded] = useState(false)
+  const [hedCopied, setHedCopied] = useState(false)
+
+  const copyHedAnnotation = () => {
+    if (annotation.hed_annotation) {
+      navigator.clipboard.writeText(annotation.hed_annotation)
+      setHedCopied(true)
+      setTimeout(() => setHedCopied(false), 2000)
+    }
+  }
 
   const handleCopy = () => {
     const textToCopy = viewMode === 'json'
@@ -150,7 +159,8 @@ export default function AnnotationViewer({ annotation, platform }: AnnotationVie
         >
           <div className="flex items-center gap-2">
             <Tag className="w-3.5 h-3.5 text-agi-orange" />
-            <span className="text-xs font-medium text-agi-teal-600 dark:text-agi-teal-400">LLM HED Annotation</span>
+            <span className="text-xs font-medium text-agi-teal-600 dark:text-agi-teal-400">HED Tags</span>
+            <span className="text-[9px] px-1.5 py-0.5 bg-agi-purple/10 dark:bg-agi-purple/20 text-agi-purple dark:text-agi-purple-300 rounded">LLM</span>
           </div>
           {hedExpanded ? (
             <ChevronUp className="w-4 h-4 text-agi-teal-500 dark:text-agi-teal-400" />
@@ -161,8 +171,21 @@ export default function AnnotationViewer({ annotation, platform }: AnnotationVie
         {hedExpanded && (
           <div className="px-3 pb-3">
             {annotation.hed_annotation ? (
-              <div className="text-xs text-agi-teal-800 dark:text-zinc-300 font-mono bg-white/50 dark:bg-black/20 rounded p-2 break-words">
-                {annotation.hed_annotation}
+              <div className="relative">
+                <button
+                  onClick={copyHedAnnotation}
+                  className="absolute top-1.5 right-1.5 p-1 rounded bg-white/50 dark:bg-black/30 hover:bg-agi-teal/10 dark:hover:bg-agi-teal/20 transition-all z-10"
+                  aria-label="Copy HED tags"
+                >
+                  {hedCopied ? (
+                    <Check className="w-3 h-3 text-green-600 dark:text-green-400" />
+                  ) : (
+                    <Copy className="w-3 h-3 text-agi-teal-600 dark:text-zinc-400" />
+                  )}
+                </button>
+                <div className="text-xs text-agi-teal-800 dark:text-zinc-300 font-mono bg-white/50 dark:bg-black/20 rounded p-2 pr-8 break-words">
+                  {annotation.hed_annotation}
+                </div>
               </div>
             ) : (
               <div className="text-xs text-agi-teal-500 dark:text-zinc-500 italic">

--- a/frontend/app/components/AnnotationViewer.tsx
+++ b/frontend/app/components/AnnotationViewer.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { PromptAnnotation, PlatformInfo } from '../types'
-import { Copy, Check, FileText, FileJson, Activity, Zap } from 'lucide-react'
+import { Copy, Check, FileText, FileJson, Activity, Zap, Tag, ExternalLink, ChevronDown, ChevronUp } from 'lucide-react'
 
 interface AnnotationViewerProps {
   annotation: PromptAnnotation
@@ -12,6 +12,7 @@ interface AnnotationViewerProps {
 export default function AnnotationViewer({ annotation, platform }: AnnotationViewerProps) {
   const [copied, setCopied] = useState(false)
   const [viewMode, setViewMode] = useState<'text' | 'json'>('text')
+  const [hedExpanded, setHedExpanded] = useState(false)
 
   const handleCopy = () => {
     const textToCopy = viewMode === 'json'
@@ -141,58 +142,90 @@ export default function AnnotationViewer({ annotation, platform }: AnnotationVie
         </div>
       </div>
 
-      {/* Metrics */}
-      {(annotation.token_metrics || annotation.performance_metrics) && (
-        <div className="grid grid-cols-2 gap-3">
-          {annotation.token_metrics && (
-            <div className="bg-agi-teal/5 dark:bg-agi-teal/10 rounded-lg p-3 border border-agi-teal/10 dark:border-agi-teal/20">
-              <div className="flex items-center gap-2 mb-2">
-                <Activity className="w-4 h-4 text-agi-orange" />
-                <span className="text-xs font-medium text-agi-teal-600 dark:text-agi-teal-400">Token Usage</span>
+      {/* LLM HED Annotation */}
+      <div className="bg-agi-teal/5 dark:bg-agi-teal/10 rounded-lg border border-agi-teal/10 dark:border-agi-teal/20">
+        <button
+          onClick={() => setHedExpanded(!hedExpanded)}
+          className="w-full px-3 py-2 flex items-center justify-between hover:bg-agi-teal/5 dark:hover:bg-agi-teal/15 transition-colors rounded-lg"
+        >
+          <div className="flex items-center gap-2">
+            <Tag className="w-3.5 h-3.5 text-agi-orange" />
+            <span className="text-xs font-medium text-agi-teal-600 dark:text-agi-teal-400">LLM HED Annotation</span>
+          </div>
+          {hedExpanded ? (
+            <ChevronUp className="w-4 h-4 text-agi-teal-500 dark:text-agi-teal-400" />
+          ) : (
+            <ChevronDown className="w-4 h-4 text-agi-teal-500 dark:text-agi-teal-400" />
+          )}
+        </button>
+        {hedExpanded && (
+          <div className="px-3 pb-3">
+            {annotation.hed_annotation ? (
+              <div className="text-xs text-agi-teal-800 dark:text-zinc-300 font-mono bg-white/50 dark:bg-black/20 rounded p-2 break-words">
+                {annotation.hed_annotation}
               </div>
-              <div className="space-y-1">
-                <div className="flex justify-between text-xs">
-                  <span className="text-agi-teal-500 dark:text-zinc-500">Input:</span>
-                  <span className="text-agi-teal-800 dark:text-zinc-300">{annotation.token_metrics.input_tokens}</span>
-                </div>
-                <div className="flex justify-between text-xs">
-                  <span className="text-agi-teal-500 dark:text-zinc-500">Output:</span>
-                  <span className="text-agi-teal-800 dark:text-zinc-300">{annotation.token_metrics.output_tokens}</span>
-                </div>
-                <div className="flex justify-between text-xs font-medium">
-                  <span className="text-agi-teal-500 dark:text-zinc-500">Total:</span>
-                  <span className="text-agi-teal dark:text-agi-teal-400">{annotation.token_metrics.total_tokens}</span>
-                </div>
+            ) : (
+              <div className="text-xs text-agi-teal-500 dark:text-zinc-500 italic">
+                No HED annotation available.{' '}
+                <a
+                  href="https://hed-bot.pages.dev"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-agi-orange hover:underline inline-flex items-center gap-1"
+                >
+                  Generate with HED-bot
+                  <ExternalLink className="w-3 h-3" />
+                </a>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Metrics - Compact */}
+      {(annotation.token_metrics || annotation.performance_metrics) && (
+        <div className="grid grid-cols-2 gap-2">
+          {annotation.token_metrics && (
+            <div className="bg-agi-teal/5 dark:bg-agi-teal/10 rounded-lg p-2 border border-agi-teal/10 dark:border-agi-teal/20">
+              <div className="flex items-center gap-1.5 mb-1">
+                <Activity className="w-3 h-3 text-agi-orange" />
+                <span className="text-[10px] font-medium text-agi-teal-600 dark:text-agi-teal-400">Tokens</span>
+              </div>
+              <div className="flex gap-2 text-[10px]">
+                <span className="text-agi-teal-500 dark:text-zinc-500">
+                  In: <span className="text-agi-teal-800 dark:text-zinc-300">{annotation.token_metrics.input_tokens}</span>
+                </span>
+                <span className="text-agi-teal-500 dark:text-zinc-500">
+                  Out: <span className="text-agi-teal-800 dark:text-zinc-300">{annotation.token_metrics.output_tokens}</span>
+                </span>
+                <span className="text-agi-teal-500 dark:text-zinc-500 font-medium">
+                  = <span className="text-agi-teal dark:text-agi-teal-400">{annotation.token_metrics.total_tokens}</span>
+                </span>
               </div>
             </div>
           )}
 
           {annotation.performance_metrics && (
-            <div className="bg-agi-teal/5 dark:bg-agi-teal/10 rounded-lg p-3 border border-agi-teal/10 dark:border-agi-teal/20">
-              <div className="flex items-center gap-2 mb-2">
-                <Zap className="w-4 h-4 text-agi-orange" />
-                <span className="text-xs font-medium text-agi-teal-600 dark:text-agi-teal-400">Performance</span>
+            <div className="bg-agi-teal/5 dark:bg-agi-teal/10 rounded-lg p-2 border border-agi-teal/10 dark:border-agi-teal/20">
+              <div className="flex items-center gap-1.5 mb-1">
+                <Zap className="w-3 h-3 text-agi-orange" />
+                <span className="text-[10px] font-medium text-agi-teal-600 dark:text-agi-teal-400">Performance</span>
               </div>
-              <div className="space-y-1">
-                <div className="flex justify-between text-xs">
-                  <span className="text-agi-teal-500 dark:text-zinc-500">Speed:</span>
-                  <span className="text-agi-teal-800 dark:text-zinc-300">
-                    {annotation.performance_metrics.tokens_per_second.toFixed(1)} t/s
-                  </span>
-                </div>
-                <div className="flex justify-between text-xs">
-                  <span className="text-agi-teal-500 dark:text-zinc-500">Time:</span>
-                  <span className="text-agi-teal-800 dark:text-zinc-300">
-                    {(annotation.performance_metrics.total_duration_ms / 1000).toFixed(2)}s
-                  </span>
-                </div>
+              <div className="flex gap-2 text-[10px] flex-wrap">
+                <span className="text-agi-teal-800 dark:text-zinc-300">
+                  {annotation.performance_metrics.tokens_per_second.toFixed(0)} t/s
+                </span>
+                <span className="text-agi-teal-500 dark:text-zinc-500">|</span>
+                <span className="text-agi-teal-800 dark:text-zinc-300">
+                  {(annotation.performance_metrics.total_duration_ms / 1000).toFixed(1)}s
+                </span>
                 {platform && platform.accelerators?.[0] && (
-                  <div className="flex justify-between text-xs">
-                    <span className="text-agi-teal-500 dark:text-zinc-500">Platform:</span>
-                    <span className="text-agi-teal-800 dark:text-zinc-300">
-                      {platform.accelerators[0].name}
+                  <>
+                    <span className="text-agi-teal-500 dark:text-zinc-500">|</span>
+                    <span className="text-agi-teal-800 dark:text-zinc-300 truncate max-w-[100px]" title={platform.accelerators[0].name}>
+                      {platform.accelerators[0].name.replace('NVIDIA GeForce ', '')}
                     </span>
-                  </div>
+                  </>
                 )}
               </div>
             </div>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,8 +4,8 @@ import { useState, useEffect, useMemo } from 'react'
 import Image from 'next/image'
 import ThumbnailRibbon from './components/ThumbnailRibbon'
 import AnnotationViewer from './components/AnnotationViewer'
-import { ImageData, Annotation, PromptAnnotation, PlatformInfo } from './types'
-import { Sparkles, ChevronDown, Loader2, ExternalLink, Sun, Moon } from 'lucide-react'
+import { ImageData, Annotation, PromptAnnotation, PlatformInfo, HumanHedData } from './types'
+import { Sparkles, ChevronDown, ChevronUp, Loader2, ExternalLink, Sun, Moon, Tag } from 'lucide-react'
 import { VERSION } from './version'
 
 export default function Dashboard() {
@@ -18,6 +18,8 @@ export default function Dashboard() {
   const [loading, setLoading] = useState(true)
   const [imageLoading, setImageLoading] = useState(false)
   const [isDark, setIsDark] = useState(false)
+  const [humanHedData, setHumanHedData] = useState<HumanHedData | null>(null)
+  const [humanHedExpanded, setHumanHedExpanded] = useState(false)
 
   // Check initial theme
   useEffect(() => {
@@ -67,6 +69,22 @@ export default function Dashboard() {
     }
 
     loadImageList()
+  }, [])
+
+  // Load human HED data
+  useEffect(() => {
+    async function loadHumanHed() {
+      try {
+        const response = await fetch(resolveUrl('human-hed.json'))
+        if (response.ok) {
+          const data = await response.json()
+          setHumanHedData(data)
+        }
+      } catch (error) {
+        console.error('Error loading human HED data:', error)
+      }
+    }
+    loadHumanHed()
   }, [])
 
   // Load annotations for selected image
@@ -262,54 +280,98 @@ export default function Dashboard() {
                 </div>
               </div>
             </div>
+
+            {/* Human HED Tags */}
+            {humanHedData && images[selectedImageIndex] && humanHedData[images[selectedImageIndex].id] && (
+              <div className="glass-card rounded-xl shadow-sm">
+                <button
+                  onClick={() => setHumanHedExpanded(!humanHedExpanded)}
+                  className="w-full px-4 py-2.5 flex items-center justify-between hover:bg-agi-teal/5 dark:hover:bg-white/5 transition-colors rounded-xl"
+                >
+                  <div className="flex items-center gap-2">
+                    <Tag className="w-4 h-4 text-agi-orange" />
+                    <span className="text-sm font-medium text-agi-teal-700 dark:text-agi-teal-300">Human HED Tags</span>
+                  </div>
+                  {humanHedExpanded ? (
+                    <ChevronUp className="w-4 h-4 text-agi-teal-500 dark:text-agi-teal-400" />
+                  ) : (
+                    <ChevronDown className="w-4 h-4 text-agi-teal-500 dark:text-agi-teal-400" />
+                  )}
+                </button>
+                {humanHedExpanded && (
+                  <div className="px-4 pb-3 space-y-2">
+                    <div className="text-xs text-agi-teal-800 dark:text-zinc-300 font-mono bg-agi-teal/5 dark:bg-agi-teal/10 rounded p-2 break-words max-h-32 overflow-y-auto">
+                      {humanHedData[images[selectedImageIndex].id].hed_short}
+                    </div>
+                    <div className="flex items-center justify-between text-[10px] text-agi-teal-500 dark:text-zinc-500">
+                      <span>COCO ID: {humanHedData[images[selectedImageIndex].id].coco_id}</span>
+                      <a
+                        href="https://github.com/MultimodalNeuroimagingLab/nsd_hed_labels"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-agi-orange hover:underline inline-flex items-center gap-1"
+                      >
+                        Source: nsd_hed_labels
+                        <ExternalLink className="w-3 h-3" />
+                      </a>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
 
           {/* Controls and Annotations - Full width on mobile, side panel on desktop */}
           <div className="flex-1 flex flex-col gap-4 min-w-0 w-full lg:w-auto">
-            {/* Model Selection */}
-            <div className="glass-card rounded-xl shadow-sm p-4">
-              <label className="block text-sm font-medium text-agi-teal-700 dark:text-agi-teal-300 mb-2">
-                Vision Model
-              </label>
-              <div className="relative">
-                <select
-                  value={selectedModel}
-                  onChange={(e) => {
-                    setSelectedModel(e.target.value)
-                    // Reset prompt selection when model changes
-                    setSelectedPromptKey('')
-                  }}
-                  className="w-full px-4 py-3 bg-stone-50 dark:bg-zinc-800 border border-agi-teal/20 dark:border-white/10 rounded-lg text-agi-teal-800 dark:text-white appearance-none focus:outline-none focus:border-agi-teal dark:focus:border-agi-teal-400 focus:ring-2 focus:ring-agi-teal/20 dark:focus:ring-agi-teal/30 transition-all"
-                >
-                  <option value="">Select a model</option>
-                  {availableModels.map(model => (
-                    <option key={model} value={model}>{model}</option>
-                  ))}
-                </select>
-                <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-agi-teal-500 dark:text-agi-teal-400 pointer-events-none" />
-              </div>
-            </div>
+            {/* Model and Annotation Type Selection - Combined Row */}
+            <div className="glass-card rounded-xl shadow-sm p-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {/* Model Selection */}
+                <div>
+                  <label className="block text-xs font-medium text-agi-teal-700 dark:text-agi-teal-300 mb-1.5">
+                    Vision Model
+                  </label>
+                  <div className="relative">
+                    <select
+                      value={selectedModel}
+                      onChange={(e) => {
+                        setSelectedModel(e.target.value)
+                        // Reset prompt selection when model changes
+                        setSelectedPromptKey('')
+                      }}
+                      className="w-full px-3 py-2 bg-stone-50 dark:bg-zinc-800 border border-agi-teal/20 dark:border-white/10 rounded-lg text-sm text-agi-teal-800 dark:text-white appearance-none focus:outline-none focus:border-agi-teal dark:focus:border-agi-teal-400 focus:ring-2 focus:ring-agi-teal/20 dark:focus:ring-agi-teal/30 transition-all"
+                    >
+                      <option value="">Select model</option>
+                      {availableModels.map(model => (
+                        <option key={model} value={model}>{model}</option>
+                      ))}
+                    </select>
+                    <ChevronDown className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-agi-teal-500 dark:text-agi-teal-400 pointer-events-none" />
+                  </div>
+                </div>
 
-            {/* Prompt Selection */}
-            <div className="glass-card rounded-xl shadow-sm p-4">
-              <label className="block text-sm font-medium text-agi-teal-700 dark:text-agi-teal-300 mb-2">
-                Annotation Type
-              </label>
-              <div className="relative">
-                <select
-                  value={selectedPromptKey}
-                  onChange={(e) => setSelectedPromptKey(e.target.value)}
-                  className="w-full px-4 py-3 bg-stone-50 dark:bg-zinc-800 border border-agi-teal/20 dark:border-white/10 rounded-lg text-agi-teal-800 dark:text-white appearance-none focus:outline-none focus:border-agi-teal dark:focus:border-agi-teal-400 focus:ring-2 focus:ring-agi-teal/20 dark:focus:ring-agi-teal/30 transition-all"
-                  disabled={!selectedModel}
-                >
-                  <option value="">Select annotation type</option>
-                  {availablePromptKeys.map(key => (
-                    <option key={key} value={key}>
-                      {formatPromptKey(key)}
-                    </option>
-                  ))}
-                </select>
-                <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-agi-teal-500 dark:text-agi-teal-400 pointer-events-none" />
+                {/* Annotation Type Selection */}
+                <div>
+                  <label className="block text-xs font-medium text-agi-teal-700 dark:text-agi-teal-300 mb-1.5">
+                    Annotation Type
+                  </label>
+                  <div className="relative">
+                    <select
+                      value={selectedPromptKey}
+                      onChange={(e) => setSelectedPromptKey(e.target.value)}
+                      className="w-full px-3 py-2 bg-stone-50 dark:bg-zinc-800 border border-agi-teal/20 dark:border-white/10 rounded-lg text-sm text-agi-teal-800 dark:text-white appearance-none focus:outline-none focus:border-agi-teal dark:focus:border-agi-teal-400 focus:ring-2 focus:ring-agi-teal/20 dark:focus:ring-agi-teal/30 transition-all"
+                      disabled={!selectedModel}
+                    >
+                      <option value="">Select type</option>
+                      {availablePromptKeys.map(key => (
+                        <option key={key} value={key}>
+                          {formatPromptKey(key)}
+                        </option>
+                      ))}
+                    </select>
+                    <ChevronDown className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-agi-teal-500 dark:text-agi-teal-400 pointer-events-none" />
+                  </div>
+                </div>
               </div>
             </div>
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image'
 import ThumbnailRibbon from './components/ThumbnailRibbon'
 import AnnotationViewer from './components/AnnotationViewer'
 import { ImageData, Annotation, PromptAnnotation, PlatformInfo, HumanHedData } from './types'
-import { Sparkles, ChevronDown, ChevronUp, Loader2, ExternalLink, Sun, Moon, Tag } from 'lucide-react'
+import { Sparkles, ChevronDown, ChevronUp, Loader2, ExternalLink, Sun, Moon, Tag, Copy, Check } from 'lucide-react'
 import { VERSION } from './version'
 
 export default function Dashboard() {
@@ -20,6 +20,15 @@ export default function Dashboard() {
   const [isDark, setIsDark] = useState(false)
   const [humanHedData, setHumanHedData] = useState<HumanHedData | null>(null)
   const [humanHedExpanded, setHumanHedExpanded] = useState(false)
+  const [humanHedCopied, setHumanHedCopied] = useState(false)
+
+  const copyHumanHed = () => {
+    if (humanHedData && images[selectedImageIndex]) {
+      navigator.clipboard.writeText(humanHedData[images[selectedImageIndex].id]?.hed_short || '')
+      setHumanHedCopied(true)
+      setTimeout(() => setHumanHedCopied(false), 2000)
+    }
+  }
 
   // Check initial theme
   useEffect(() => {
@@ -290,7 +299,8 @@ export default function Dashboard() {
                 >
                   <div className="flex items-center gap-2">
                     <Tag className="w-4 h-4 text-agi-orange" />
-                    <span className="text-sm font-medium text-agi-teal-700 dark:text-agi-teal-300">Human HED Tags</span>
+                    <span className="text-sm font-medium text-agi-teal-700 dark:text-agi-teal-300">HED Tags</span>
+                    <span className="text-[10px] px-1.5 py-0.5 bg-agi-teal/10 dark:bg-agi-teal/20 text-agi-teal-600 dark:text-agi-teal-400 rounded">Human</span>
                   </div>
                   {humanHedExpanded ? (
                     <ChevronUp className="w-4 h-4 text-agi-teal-500 dark:text-agi-teal-400" />
@@ -300,8 +310,21 @@ export default function Dashboard() {
                 </button>
                 {humanHedExpanded && (
                   <div className="px-4 pb-3 space-y-2">
-                    <div className="text-xs text-agi-teal-800 dark:text-zinc-300 font-mono bg-agi-teal/5 dark:bg-agi-teal/10 rounded p-2 break-words max-h-32 overflow-y-auto">
-                      {humanHedData[images[selectedImageIndex].id].hed_short}
+                    <div className="relative">
+                      <button
+                        onClick={copyHumanHed}
+                        className="absolute top-1.5 right-1.5 p-1 rounded bg-white/50 dark:bg-black/30 hover:bg-agi-teal/10 dark:hover:bg-agi-teal/20 transition-all z-10"
+                        aria-label="Copy HED tags"
+                      >
+                        {humanHedCopied ? (
+                          <Check className="w-3 h-3 text-green-600 dark:text-green-400" />
+                        ) : (
+                          <Copy className="w-3 h-3 text-agi-teal-600 dark:text-zinc-400" />
+                        )}
+                      </button>
+                      <div className="text-xs text-agi-teal-800 dark:text-zinc-300 font-mono bg-agi-teal/5 dark:bg-agi-teal/10 rounded p-2 pr-8 break-words max-h-32 overflow-y-auto">
+                        {humanHedData[images[selectedImageIndex].id].hed_short}
+                      </div>
                     </div>
                     <div className="flex items-center justify-between text-[10px] text-agi-teal-500 dark:text-zinc-500">
                       <span>COCO ID: {humanHedData[images[selectedImageIndex].id].coco_id}</span>

--- a/frontend/app/types.ts
+++ b/frontend/app/types.ts
@@ -11,6 +11,7 @@ export interface PromptAnnotation {
   response_format: string
   response_data?: any
   error?: string | null
+  hed_annotation?: string  // HED annotation for this description (from HED-bot)
   token_metrics?: {
     input_tokens: number
     output_tokens: number
@@ -57,3 +58,12 @@ export interface AnnotationFile {
     [key: string]: any
   }
 }
+
+export interface HumanHedEntry {
+  hed_short: string
+  hed_long: string
+  coco_id: string
+  nsd_id: string
+}
+
+export type HumanHedData = Record<string, HumanHedEntry>

--- a/frontend/app/version.ts
+++ b/frontend/app/version.ts
@@ -2,11 +2,11 @@
  * Version information for Image Annotation Dashboard.
  */
 
-export const VERSION = "0.1.5-beta";
+export const VERSION = "0.2.0-beta";
 export const VERSION_INFO = {
   major: 0,
-  minor: 1,
-  patch: 5,
+  minor: 2,
+  patch: 0,
   prerelease: "beta"
 } as const;
 

--- a/frontend/public/human-hed.json
+++ b/frontend/public/human-hed.json
@@ -1,0 +1,6002 @@
+{
+  "shared0001_nsd02951": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object)), (Background-view, ((Human, Body, Agent-trait/Adult), Outdoors, Furnishing, Natural-feature/Sky, Urban, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Furnishing,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Item/Object/Man-made-object))",
+    "coco_id": "262145",
+    "nsd_id": "2950"
+  },
+  "shared0002_nsd02991": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Agent-trait/Adult)), (Item-count/1, (Human, Body, (Face, Away-from), Male, Agent-trait/Adult)), ((Item-count, High), Furnishing))), (Background-view, (Ingestible-object, Furnishing, Room, Indoors, Man-made-object, Assistive-device))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Ingestible-object,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object,Item/Object/Man-made-object/Device/Assistive-device))",
+    "coco_id": "262239",
+    "nsd_id": "2990"
+  },
+  "shared0003_nsd03050": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adolescent)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "262414",
+    "nsd_id": "3049"
+  },
+  "shared0004_nsd03078": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object))), (Item-count/1, River), (Item-count/3, Man-made-object), Terrain/Sand)), (Background-view, (Mountain, Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object),Property/Environmental-property/Terrain/Sand)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Mountain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "524646",
+    "nsd_id": "3077"
+  },
+  "shared0005_nsd03147": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/1, Clock-face), (Item-count/1, Roof), (Item-Count/1, Entrance))), (Background-view, (Grassy-terrain,  Path, Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Roof),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Entrance))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Man-made-object/Navigational-object/Path,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "262690",
+    "nsd_id": "3146"
+  },
+  "shared0006_nsd03158": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object)), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "584",
+    "nsd_id": "3157"
+  },
+  "shared0007_nsd03165": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Ingestible-object), (Item-count/2, Furnishing), (Item-count/1, Assistive-device))), (Background-view, (Ingestible-object, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Ingestible-object,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "605",
+    "nsd_id": "3164"
+  },
+  "shared0008_nsd03172": {
+    "hed_short": "(Foreground-view, ((Item-count/3, ((Human, Human-agent), Body, Female, Agent-trait/Adolescent)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors, Field, Grassy-terrain, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Terrain/Grassy-terrain,Item/Biological-item/Organism/Plant))",
+    "coco_id": "625",
+    "nsd_id": "3171"
+  },
+  "shared0009_nsd03182": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Plant, Car, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Vehicle/Car,Property/Environmental-property/Outdoors))",
+    "coco_id": "650",
+    "nsd_id": "3181"
+  },
+  "shared0010_nsd03387": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "1308",
+    "nsd_id": "3386"
+  },
+  "shared0011_nsd03435": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/2, Word))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "263599",
+    "nsd_id": "3434"
+  },
+  "shared0012_nsd03450": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, Agent-trait/Child)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Child)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "525790",
+    "nsd_id": "3449"
+  },
+  "shared0013_nsd03490": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Plant, River, Grassy-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/River,Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "525932",
+    "nsd_id": "3489"
+  },
+  "shared0014_nsd03627": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Away-from), Agent-trait/Adult)), (Item-count/1, Laptop-computer))), (Background-view, (Furnishing, Room, Indoors, Animal, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Biological-item/Organism/Animal,Item/Biological-item/Organism/Plant))",
+    "coco_id": "264244",
+    "nsd_id": "3626"
+  },
+  "shared0015_nsd03683": {
+    "hed_short": "(Foreground-view, (Item-count/1, Train)), (Background-view, (Outdoors, Urban, Mountain, River, Composite-terrain, Car, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Mountain,Item/Object/Natural-object/Natural-feature/River,Property/Environmental-property/Terrain/Composite-terrain,Item/Object/Man-made-object/Vehicle/Car,Item/Object/Man-made-object/Building))",
+    "coco_id": "264396",
+    "nsd_id": "3682"
+  },
+  "shared0016_nsd03688": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Book), ((Item-count, High), Furnishing))), (Background-view, (Room, Indoors, Man-made-object/Musical-instrument, Plant, Entrance, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Document/Book),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Musical-instrument,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building/Entrance,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "2270",
+    "nsd_id": "3687"
+  },
+  "shared0017_nsd03730": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), (Item-count/1, Microphone), (Item-count/1, Pen))), (Background-view, (Indoors, Display-device))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Microphone),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device/Writing-device/Pen))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Device/IO-device/Output-device/Display-device))",
+    "coco_id": "2372",
+    "nsd_id": "3729"
+  },
+  "shared0018_nsd03810": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Animal, Animal-agent)), Run)), (Background-view, (Outdoors, Grassy-terrain, Mountain, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Animal,Agent/Animal-agent)),Action/Move/Move-body-part/Move-lower-extremity/Run)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Mountain,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "264735",
+    "nsd_id": "3809"
+  },
+  "shared0019_nsd03843": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Grassy-terrain, Field, Car, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Object/Man-made-object/Vehicle/Car,Property/Environmental-property/Outdoors))",
+    "coco_id": "526968",
+    "nsd_id": "3842"
+  },
+  "shared0020_nsd03848": {
+    "hed_short": "(Foreground-view, (Item-count/1, Furnishing)), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "526980",
+    "nsd_id": "3847"
+  },
+  "shared0021_nsd03857": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Agent-trait/Infant, Male)), (Item-count/1, (Human, Body, (Face, Towards), Agent-trait/Child, Male)), (Item-count/1, Book), ((Item-count, High), Word))), (Background-view, (Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Infant,Property/Agent-property/Agent-trait/Sex/Male)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Child,Property/Agent-property/Agent-trait/Sex/Male)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Document/Book),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "274108",
+    "nsd_id": "3856"
+  },
+  "shared0022_nsd03914": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body, (Face, Towards), Agent-trait/Adult)),  (Item-count/2, Man-made-object/Toy))), (Background-view, (Outdoors, Sloped-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Sloped-terrain))",
+    "coco_id": "265023",
+    "nsd_id": "3913"
+  },
+  "shared0023_nsd03952": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/2, Clock-face))), (Background-view, (Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "265150",
+    "nsd_id": "3951"
+  },
+  "shared0024_nsd04052": {
+    "hed_short": "(Foreground-view, ((Item-count/2, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Action/Ride, (Item-count/2, (Animal, Animal-agent)), Walk))), (Background-view, (Path, Outdoors, Plant, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Animal,Agent/Animal-agent)),Action/Move/Move-body-part/Move-lower-extremity/Walk))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Path,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural))",
+    "coco_id": "265453",
+    "nsd_id": "4051"
+  },
+  "shared0025_nsd04059": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Grassy-terrain, Field, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors))",
+    "coco_id": "527618",
+    "nsd_id": "4058"
+  },
+  "shared0026_nsd04130": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Man-made-object/Toy), (Item-count/1, Man-made-object/Musical-instrument), (Item-count/1, Furnishing), ((Item-count, High), Plant))), (Background-view, (Room, Entrance, Indoors, (Human, Body, Agent-trait/Adult), (Human, Body, Male, Agent-trait/Child)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Musical-instrument),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Item/Object/Man-made-object/Building/Entrance,Property/Environmental-property/Indoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Child)))",
+    "coco_id": "3521",
+    "nsd_id": "4129"
+  },
+  "shared0027_nsd04157": {
+    "hed_short": "(Foreground-view, (Item-count/3, Ingestible-object)), (Background-view, (Furnishing, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors))",
+    "coco_id": "265745",
+    "nsd_id": "4156"
+  },
+  "shared0028_nsd04250": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), ((Item-count, High), Character), (Item-count/1, Icon), Terrain/Sand)), (Background-view, (Natural-feature/Ocean, Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Character),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Image/Icon),Property/Environmental-property/Terrain/Sand)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "558788",
+    "nsd_id": "4249"
+  },
+  "shared0029_nsd04326": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), ((Item-count, High), Plant))), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "393907",
+    "nsd_id": "4325"
+  },
+  "shared0030_nsd04424": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Agent-trait/Child, Female)), (Item-count/1, Furnishing))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Child,Property/Agent-property/Agent-trait/Sex/Female)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "4442",
+    "nsd_id": "4423"
+  },
+  "shared0031_nsd04437": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Ingestible-object), (Item-count/1, Furnishing))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "266622",
+    "nsd_id": "4436"
+  },
+  "shared0032_nsd04613": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Towards), Agent-trait/Adult)), (Item-count/1, Laptop-computer), (Item-count/1, Ingestible-object), (Item-count/1, Furnishing))), (Background-view, (Indoors, Furnishing, Room, Book, Man-made-object, Entrance))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Item/Object/Man-made-object/Document/Book,Item/Object/Man-made-object,Item/Object/Man-made-object/Building/Entrance))",
+    "coco_id": "5028",
+    "nsd_id": "4612"
+  },
+  "shared0033_nsd04668": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/3, Furnishing))), (Background-view, (Room, Indoors, Art-installation))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Media/Visualization/Art-installation))",
+    "coco_id": "267338",
+    "nsd_id": "4667"
+  },
+  "shared0034_nsd04691": {
+    "hed_short": "(Background-view, (Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "5277",
+    "nsd_id": "4690"
+  },
+  "shared0035_nsd04769": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Ingestible-object), ((Item-count, High), Icon), (Item-count/1, Assistive-device))), (Background-view, (Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Media/Visualization/Image/Icon),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "267647",
+    "nsd_id": "4768"
+  },
+  "shared0036_nsd04787": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, Agent-trait/Adult)), (Item-count/3, Vehicle), ((Item-count, High), Car), (Item-count/2, Man-made-object), (Item-count/1, Road), ((Item-count, High), Plant))), (Background-view, (Car, Vehicle, Road, Building, Urban, Outdoors, Paved-terrain, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Vehicle),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle/Car),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Vehicle/Car,Item/Object/Man-made-object/Vehicle,Item/Object/Man-made-object/Navigational-object/Road,Item/Object/Man-made-object/Building,Property/Environmental-property/Urban,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Biological-item/Organism/Plant))",
+    "coco_id": "267699",
+    "nsd_id": "4786"
+  },
+  "shared0037_nsd04836": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Vehicle), (Item-count/2, Word), (Item-count/1, Road), (Item-count/1, Plant))), (Background-view, (Outdoors, Car, Building, Paved-terrain, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Vehicle/Car,Item/Object/Man-made-object/Building,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Urban))",
+    "coco_id": "5684",
+    "nsd_id": "4835"
+  },
+  "shared0038_nsd04870": {
+    "hed_short": "(Foreground-view, (Item-count/3, Ingestible-object)), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "312536",
+    "nsd_id": "4869"
+  },
+  "shared0039_nsd04893": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), Terrain/Sand)), (Background-view, (Outdoors, Grassy-terrain, Furnishing, Roof, (Human, Body, Male, Agent-trait/Adult)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),Property/Environmental-property/Terrain/Sand)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Roof,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)))",
+    "coco_id": "268008",
+    "nsd_id": "4892"
+  },
+  "shared0040_nsd04931": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Boat), (Item-count/1, River), (Item-count/1, Path))), (Background-view, (Outdoors, Composite-terrain, Hill, Plant, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Vehicle/Boat),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Composite-terrain,Item/Object/Natural-object/Natural-feature/Hill,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural))",
+    "coco_id": "268114",
+    "nsd_id": "4930"
+  },
+  "shared0041_nsd05035": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "268418",
+    "nsd_id": "5034"
+  },
+  "shared0042_nsd05107": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Animal, Animal-agent)), Walk)), (Background-view, (Dirt-terrain, Outdoors, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent)),Action/Move/Move-body-part/Move-lower-extremity/Walk)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Dirt-terrain,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building))",
+    "coco_id": "268659",
+    "nsd_id": "5106"
+  },
+  "shared0043_nsd05205": {
+    "hed_short": "(Foreground-view, (Item-count/1, Train)), (Background-view, (Outdoors, Grassy-terrain, Hill, Building, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Hill,Item/Object/Man-made-object/Building,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "6765",
+    "nsd_id": "5204"
+  },
+  "shared0044_nsd05286": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Animal)), (Background-view, (Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "7048",
+    "nsd_id": "5285"
+  },
+  "shared0045_nsd05302": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Furnishing), ((Item-count, High), Plant))), (Background-view, (Indoors, Man-made-object/Musical-instrument))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Musical-instrument))",
+    "coco_id": "531392",
+    "nsd_id": "5301"
+  },
+  "shared0046_nsd05339": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Building, Car, Grassy-terrain, Field, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Vehicle/Car,Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "531515",
+    "nsd_id": "5338"
+  },
+  "shared0047_nsd05428": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Ingestible-object), (Item-count/1, (Human, Body)))), (Background-view, (Paved-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "531828",
+    "nsd_id": "5427"
+  },
+  "shared0048_nsd05460": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/1, Word))), (Background-view, (Runway, Outdoors, Icon, Field, Mountain, Building, Aircraft))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Runway,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Media/Visualization/Image/Icon,Item/Object/Natural-object/Natural-feature/Field,Item/Object/Natural-object/Natural-feature/Mountain,Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Vehicle/Aircraft))",
+    "coco_id": "11299",
+    "nsd_id": "5459"
+  },
+  "shared0049_nsd05503": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Vehicle), (Item-count/2, Man-made-object), (Item-count/1, Road), (Item-count/1, Path))), (Background-view, (Urban, Outdoors, Paved-terrain, Car, (Human, Body, Agent-trait/Older-adult), Building, Bicycle, Plant, Vehicle))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Urban,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Man-made-object/Vehicle/Car,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Older-adult),Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Vehicle/Bicycle,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Vehicle))",
+    "coco_id": "219750",
+    "nsd_id": "5502"
+  },
+  "shared0050_nsd05543": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Away-from), Agent-trait/Adult)), (Item-count/1, ((Human, Human-agent), Body, Female, (Face, Away-from), Agent-trait/Adolescent))), (Play, (Item-count/3, Man-made-object/Toy)))), (Background-view, (Outdoors, Urban, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adolescent))),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building))",
+    "coco_id": "7932",
+    "nsd_id": "5542"
+  },
+  "shared0051_nsd05575": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Plant), (Item-count/1, Animal))), (Background-view, (Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "8027",
+    "nsd_id": "5574"
+  },
+  "shared0052_nsd05584": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, Agent-trait/Adult)), (Walk, (Item-count/1, Man-made-object)))), (Background-view, (Paved-terrain, Path, Building, Urban, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Action/Move/Move-body-part/Move-lower-extremity/Walk,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Man-made-object/Navigational-object/Path,Item/Object/Man-made-object/Building,Property/Environmental-property/Urban,Property/Environmental-property/Outdoors))",
+    "coco_id": "8053",
+    "nsd_id": "5583"
+  },
+  "shared0053_nsd05603": {
+    "hed_short": "(Foreground-view, (Natural-feature/Ocean, (Item-count/3, 2D-Shape), Terrain/Sand)), (Background-view, (Outdoors, Natural-feature/Sky, Building, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Item/Object/Natural-object/Natural-feature/Ocean,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Geometric-object/2D-shape),Property/Environmental-property/Terrain/Sand)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant))",
+    "coco_id": "270278",
+    "nsd_id": "5602"
+  },
+  "shared0054_nsd05715": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Aircraft)), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle/Aircraft)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "532753",
+    "nsd_id": "5714"
+  },
+  "shared0055_nsd05879": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Boat), (Item-count/1, River))), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Vehicle/Boat),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "533231",
+    "nsd_id": "5878"
+  },
+  "shared0056_nsd05891": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Building), (Item-count/1, Clock-face))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "8998",
+    "nsd_id": "5890"
+  },
+  "shared0057_nsd06133": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Bicycle), (Item-count/1, Furnishing))), (Background-view, (Vehicle, Paved-terrain, Road, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Bicycle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Vehicle,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Man-made-object/Navigational-object/Road,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "1625",
+    "nsd_id": "6132"
+  },
+  "shared0058_nsd06200": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), (Item-count/2, Word))), (Background-view, (Mountain, Composite-terrain, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Mountain,Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "534259",
+    "nsd_id": "6199"
+  },
+  "shared0059_nsd06223": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Ingestible-object), (Item-count/2, Furnishing))), (Background-view, (Ingestible-object, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Ingestible-object,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "10046",
+    "nsd_id": "6222"
+  },
+  "shared0060_nsd06432": {
+    "hed_short": "(Foreground-view, (((Item-count/3, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), (Item-count/2, Character))), (Background-view, (Composite-terrain, Field, Icon, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/3,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Object/Man-made-object/Media/Visualization/Image/Icon,Property/Environmental-property/Outdoors))",
+    "coco_id": "10710",
+    "nsd_id": "6431"
+  },
+  "shared0061_nsd06445": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Action/Ride, (Item-count/1, Bicycle))), (Item-count/1, Road), (Item-count/2, Car), (Item-count/1, Truck))), (Background-view, (Building, Urban, Outdoors, Man-made-object, (Human, Body, Agent-trait/Adult), Car))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Bicycle))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Vehicle/Car),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Truck))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Urban,Property/Environmental-property/Outdoors,Item/Object/Man-made-object,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Item/Object/Man-made-object/Vehicle/Car))",
+    "coco_id": "272901",
+    "nsd_id": "6444"
+  },
+  "shared0062_nsd06490": {
+    "hed_short": "(Foreground-view, (Item-count/4, Furnishing)), (Background-view, (Furnishing, Room, Plant, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Item/Biological-item/Organism/Plant,Property/Environmental-property/Indoors))",
+    "coco_id": "10903",
+    "nsd_id": "6489"
+  },
+  "shared0063_nsd06515": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), (Item-count/2, Word))), (Background-view, ((Human, Body, Agent-trait/Adolescent), Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adolescent),Property/Environmental-property/Outdoors))",
+    "coco_id": "273120",
+    "nsd_id": "6514"
+  },
+  "shared0064_nsd06522": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object)), (Background-view, (Furnishing, Assistive-device))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Device/Assistive-device))",
+    "coco_id": "273138",
+    "nsd_id": "6521"
+  },
+  "shared0065_nsd06525": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Sloped-terrain, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "273147",
+    "nsd_id": "6524"
+  },
+  "shared0066_nsd06559": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Ingestible-object), ((Item-count, High), Furnishing))), (Background-view, ((Human, Body), Indoors, Furnishing, Room, Assistive-device, Ingestible-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Item/Object/Man-made-object/Device/Assistive-device,Item/Object/Ingestible-object))",
+    "coco_id": "273250",
+    "nsd_id": "6558"
+  },
+  "shared0067_nsd06641": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "11358",
+    "nsd_id": "6640"
+  },
+  "shared0068_nsd06714": {
+    "hed_short": "(Foreground-view, (((Item-count/2, ((Human, Human-agent), Body, Agent-trait/Child)), (Play, (Item-count/2, Man-made-object/Toy))), Paved-terrain)), (Background-view, (Outdoors, Composite-terrain, Building, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/2,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Child)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),Property/Environmental-property/Terrain/Paved-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Composite-terrain,Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant))",
+    "coco_id": "535871",
+    "nsd_id": "6713"
+  },
+  "shared0069_nsd06802": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, Female, Agent-trait/Adult)), (Item-count/1, Furnishing), (Item-count/1, Road))), (Background-view, (Photograph, Outdoors, Truck))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Media/Visualization/Image/Photograph,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Vehicle/Truck))",
+    "coco_id": "11856",
+    "nsd_id": "6801"
+  },
+  "shared0070_nsd07008": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Plant, Grassy-terrain, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "536786",
+    "nsd_id": "7007"
+  },
+  "shared0071_nsd07040": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Man-made-object), ((Item-count, High), Plant))), (Background-view, (Outdoors, Path, Road, Composite-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Navigational-object/Path,Item/Object/Man-made-object/Navigational-object/Road,Property/Environmental-property/Terrain/Composite-terrain))",
+    "coco_id": "536884",
+    "nsd_id": "7039"
+  },
+  "shared0072_nsd07121": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Walk, (Item-count/1, Man-made-object))), Terrain/Sand)), (Background-view, (Outdoors, Natural-feature/Ocean, (Human, Body), Mountain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Move/Move-body-part/Move-lower-extremity/Walk,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),Property/Environmental-property/Terrain/Sand)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Natural-object/Natural-feature/Mountain))",
+    "coco_id": "274978",
+    "nsd_id": "7120"
+  },
+  "shared0073_nsd07208": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Plant, Uneven-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Uneven-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "537393",
+    "nsd_id": "7207"
+  },
+  "shared0074_nsd07337": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object)), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "275663",
+    "nsd_id": "7336"
+  },
+  "shared0075_nsd07367": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Man-made-object/Toy), (Item-count/1, River))), (Background-view, (Grassy-terrain, Field, Mountain, Natural-feature/Sky, Outdoors, (Human, Body), Path))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Object/Natural-object/Natural-feature/Mountain,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Navigational-object/Path))",
+    "coco_id": "399878",
+    "nsd_id": "7366"
+  },
+  "shared0076_nsd07410": {
+    "hed_short": "(Foreground-view, (Item-count/1, Train)), (Background-view, (Outdoors, Mountain, River, Plant, Composite-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Mountain,Item/Object/Natural-object/Natural-feature/River,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Composite-terrain))",
+    "coco_id": "275902",
+    "nsd_id": "7409"
+  },
+  "shared0077_nsd07419": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Child)), (Item-count/1, Man-made-object/Toy))), (Background-view, (Natural-feature/Sky, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "275938",
+    "nsd_id": "7418"
+  },
+  "shared0078_nsd07481": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Furnishing), (Item-count/1, Ingestible-object), (Item-count/1, Assistive-device))), (Background-view, ((Human, Body, Agent-trait/Adolescent), Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adolescent),Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "13969",
+    "nsd_id": "7480"
+  },
+  "shared0079_nsd07655": {
+    "hed_short": "(Foreground-view, (Item-count/1, Boat)), (Background-view, (Furnishing, Room, Indoors, Assistive-device))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Boat)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Device/Assistive-device))",
+    "coco_id": "276664",
+    "nsd_id": "7654"
+  },
+  "shared0080_nsd07660": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body)), (Item-count/1, Tool))), (Background-view, (Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Tool))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "538822",
+    "nsd_id": "7659"
+  },
+  "shared0081_nsd07841": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Man-made-object/Toy), (Item-count/1, Clothing))), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Clothing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "539340",
+    "nsd_id": "7840"
+  },
+  "shared0082_nsd07860": {
+    "hed_short": "(Foreground-view, (Item-count/1, Train)), (Background-view, (Outdoors, Rural, Plant, Grassy-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Grassy-terrain))",
+    "coco_id": "539395",
+    "nsd_id": "7859"
+  },
+  "shared0083_nsd07945": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Road, Plant, Composite-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Road,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "277524",
+    "nsd_id": "7944"
+  },
+  "shared0084_nsd07949": {
+    "hed_short": "(Foreground-view, (Natural-feature/Ocean, (Item-count/1, Boat))), (Background-view, (Natural-feature/Sky, Building, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Item/Object/Natural-object/Natural-feature/Ocean,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Boat))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors))",
+    "coco_id": "570543",
+    "nsd_id": "7948"
+  },
+  "shared0085_nsd07955": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Boat), (Item-count/1, River))), (Background-view, (Plant, Composite-terrain, Outdoors, Building, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle/Boat),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "539705",
+    "nsd_id": "7954"
+  },
+  "shared0086_nsd08007": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean, Mountain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Mountain))",
+    "coco_id": "539879",
+    "nsd_id": "8006"
+  },
+  "shared0087_nsd08110": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Outdoors, Dirt-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Dirt-terrain))",
+    "coco_id": "300383",
+    "nsd_id": "8109"
+  },
+  "shared0088_nsd08205": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "540538",
+    "nsd_id": "8204"
+  },
+  "shared0089_nsd08226": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, (Face, Away-from), Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors, Grassy-terrain, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Item/Biological-item/Organism/Plant))",
+    "coco_id": "16314",
+    "nsd_id": "8225"
+  },
+  "shared0090_nsd08263": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, Agent-trait/Adult)), (Item-count/1, Man-made-object))), (Background-view, (Outdoors, Natural-feature/Ocean, Rocky-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Terrain/Rocky-terrain))",
+    "coco_id": "278555",
+    "nsd_id": "8262"
+  },
+  "shared0091_nsd08275": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Animal)), (Background-view, (Grassy-terrain, Field, Plant, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "540735",
+    "nsd_id": "8274"
+  },
+  "shared0092_nsd08319": {
+    "hed_short": "(Background-view, (Furnishing, Room, Plant, Painting, Sculpture, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Media/Visualization/Image/Painting,Item/Object/Man-made-object/Media/Visualization/Sculpture,Property/Environmental-property/Indoors))",
+    "coco_id": "278714",
+    "nsd_id": "8318"
+  },
+  "shared0093_nsd08388": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Action/Ride, (Item-count/1, Bicycle))), (Item-count/1, Car), (Item-count/1, Road))), (Background-view, (Building, Outdoors, Plant, Natural-feature/Sky, Urban, Man-made-object, (Human, Body), Bicycle, Car))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Bicycle))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Item/Object/Man-made-object,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Vehicle/Bicycle,Item/Object/Man-made-object/Vehicle/Car))",
+    "coco_id": "541077",
+    "nsd_id": "8387"
+  },
+  "shared0094_nsd08395": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Ingestible-object), (Item-count/1, Man-made-object))), (Background-view, (Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "278962",
+    "nsd_id": "8394"
+  },
+  "shared0095_nsd08416": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/2, Clock-face))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "16898",
+    "nsd_id": "8415"
+  },
+  "shared0096_nsd08436": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Ingestible-object), (Item-count/2, Furnishing))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "541258",
+    "nsd_id": "8435"
+  },
+  "shared0097_nsd08466": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "279197",
+    "nsd_id": "8465"
+  },
+  "shared0098_nsd08510": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing)))",
+    "coco_id": "541472",
+    "nsd_id": "8509"
+  },
+  "shared0099_nsd08632": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, ((Human, Body, Agent-trait/Adult), Furnishing, Room, Indoors, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object))",
+    "coco_id": "271183",
+    "nsd_id": "8631"
+  },
+  "shared0100_nsd08647": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), ((Item-count, High), Ingestible-object), (Item-count/1, Man-made-object))), (Background-view, (Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "541856",
+    "nsd_id": "8646"
+  },
+  "shared0101_nsd08808": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body, Agent-trait/Adult)), (Item-count/4, Face, Away-from), (Item-count/2, Furnishing), (Item-count/3, Assistive-device))), (Background-view, (Indoors, Ingestible-object, Furnishing, Book, Room))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Device/Assistive-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Ingestible-object,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Document/Book,Item/Object/Man-made-object/Building/Room))",
+    "coco_id": "17967",
+    "nsd_id": "8807"
+  },
+  "shared0102_nsd08844": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/2, Clock-face))), (Background-view, (Urban, Outdoors, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Urban,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building))",
+    "coco_id": "18078",
+    "nsd_id": "8843"
+  },
+  "shared0103_nsd08926": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Truck), ((Item-count, High), Plant), (Item-count/1, (Human, Body, Male, Agent-trait/Adult)), (Item-count/1, Furnishing))), (Background-view, (Road, Car, (Human, Body), Path, Composite-terrain, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Truck),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Road,Item/Object/Man-made-object/Vehicle/Car,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Navigational-object/Path,Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Urban))",
+    "coco_id": "280484",
+    "nsd_id": "8925"
+  },
+  "shared0104_nsd08934": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, (Face, Towards), Male, Agent-trait/Adolescent)), ((Action/Ride, (Item-count/1, (Animal, Animal-agent))), Walk))), (Background-view, (Path, Outdoors, Plant, Grassy-terrain, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adolescent)),((Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent))),Action/Move/Move-body-part/Move-lower-extremity/Walk))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Path,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Rural))",
+    "coco_id": "18367",
+    "nsd_id": "8933"
+  },
+  "shared0105_nsd09028": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Away-from), Agent-trait/Child)), (Item-count/1, Man-made-object/Toy))), (Background-view, (Paved-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "280764",
+    "nsd_id": "9027"
+  },
+  "shared0106_nsd09049": {
+    "hed_short": "(Background-view, (Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "280808",
+    "nsd_id": "9048"
+  },
+  "shared0107_nsd09148": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "543254",
+    "nsd_id": "9147"
+  },
+  "shared0108_nsd09231": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Boat), (Item-count/1, Path))), (Background-view, (River, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Vehicle/Boat),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/River,Property/Environmental-property/Outdoors))",
+    "coco_id": "281330",
+    "nsd_id": "9230"
+  },
+  "shared0109_nsd09435": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Rocky-terrain, Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Rocky-terrain,Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "544060",
+    "nsd_id": "9434"
+  },
+  "shared0110_nsd09463": {
+    "hed_short": "(Foreground-view, (Item-count/1, Train)), (Background-view, (Paved-terrain, Indoors, Furnishing, Room))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room))",
+    "coco_id": "19863",
+    "nsd_id": "9462"
+  },
+  "shared0111_nsd09681": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/2, Clock-face), (Item-count/1, Road), (Item-count/1, Man-made-object), (Item-count/1, Car))), (Background-view, (Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Urban))",
+    "coco_id": "20517",
+    "nsd_id": "9680"
+  },
+  "shared0112_nsd09723": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Towards), Agent-trait/Adult)), (Action/Ride, (Item-count/1, Bicycle)))), (Background-view, (Path, Plant, Outdoors, Composite-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Bicycle)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Path,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Composite-terrain))",
+    "coco_id": "544926",
+    "nsd_id": "9722"
+  },
+  "shared0113_nsd09805": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Furnishing), (Item-count/3, Ingestible-object), (Item-count/1, Laptop-computer), (Item-count/1, Computer-mouse))), (Background-view, (Room, Indoors, Furnishing, Sculpture, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Media/Visualization/Sculpture,Item/Object/Man-made-object))",
+    "coco_id": "545160",
+    "nsd_id": "9804"
+  },
+  "shared0114_nsd09848": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Natural-feature/Ocean, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "571485",
+    "nsd_id": "9847"
+  },
+  "shared0115_nsd09866": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object))",
+    "coco_id": "21095",
+    "nsd_id": "9865"
+  },
+  "shared0116_nsd09918": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/1, Word), (Item-count/2, Runway), Grassy-terrain)), (Background-view, (Hill, Outdoors, Building, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Navigational-object/Runway),Property/Environmental-property/Terrain/Grassy-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Hill,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "283426",
+    "nsd_id": "9917"
+  },
+  "shared0117_nsd09979": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors, Dirt-terrain, Furnishing, (Human, Body, Male, Agent-trait/Child)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Dirt-terrain,Item/Object/Man-made-object/Furnishing,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Child)))",
+    "coco_id": "396793",
+    "nsd_id": "9978"
+  },
+  "shared0118_nsd10007": {
+    "hed_short": "(Foreground-view, (((Item-count/3, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Man-made-object/Toy))), Composite-terrain, (Item-count/1, Word), (Item-count/1, Character), (Item-count/2, Man-made-object/Toy))), (Background-view, (Outdoors, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/3,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Item/Object/Man-made-object/Toy))),Property/Environmental-property/Terrain/Composite-terrain,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Character),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "283678",
+    "nsd_id": "10006"
+  },
+  "shared0119_nsd10047": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, (Face, Towards), Female, Agent-trait/Adolescent)), (Action/Ride, (Item-count/1, (Animal, Animal-agent)), Walk))), (Background-view, (Path, Outdoors, Plant, Dirt-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adolescent)),(Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent)),Action/Move/Move-body-part/Move-lower-extremity/Walk))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Path,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Dirt-terrain))",
+    "coco_id": "545950",
+    "nsd_id": "10046"
+  },
+  "shared0120_nsd10065": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing), (Item-count/1, Assistive-device))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "21718",
+    "nsd_id": "10064"
+  },
+  "shared0121_nsd10106": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/1, Runway), (Item-count/3, Word), (Item-count/1, Icon), Grassy-terrain)), (Background-view, (Natural-feature/Sky, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Runway),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Image/Icon),Property/Environmental-property/Terrain/Grassy-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "546140",
+    "nsd_id": "10105"
+  },
+  "shared0122_nsd10108": {
+    "hed_short": "(Foreground-view, ((Item-count/4, (Human, Body, Male, Agent-trait/Adult)), (Item-count/1, Laptop-computer), (Item-count/1, Path), (Item-count/2, Furnishing))), (Background-view, (Plant, Composite-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "546147",
+    "nsd_id": "10107"
+  },
+  "shared0123_nsd10245": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), ((Item-count, High), Ingestible-object), (Item-count/1, Clock-face))), (Background-view, (Building, Urban, Room, Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "22256",
+    "nsd_id": "10244"
+  },
+  "shared0124_nsd10394": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Furnishing), (Item-count/1, Photograph), (Item-count/1, Man-made-object))), (Background-view, (Room, Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Image/Photograph),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "122964",
+    "nsd_id": "10393"
+  },
+  "shared0125_nsd10472": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Towards), Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Grassy-terrain, Outdoors, (Human, Body, Agent-trait/Adult)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)))",
+    "coco_id": "22964",
+    "nsd_id": "10471"
+  },
+  "shared0126_nsd10508": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Plant), (Item-count/1, Ingestible-object)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Ingestible-object)))",
+    "coco_id": "547367",
+    "nsd_id": "10507"
+  },
+  "shared0127_nsd10587": {
+    "hed_short": "(Foreground-view, (Item-count/1, Furnishing)), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "285450",
+    "nsd_id": "10586"
+  },
+  "shared0128_nsd10601": {
+    "hed_short": "(Background-view, (Furnishing, Room, Indoors, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object))",
+    "coco_id": "547644",
+    "nsd_id": "10600"
+  },
+  "shared0129_nsd10611": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, (Face, Towards), Agent-trait/Adult)), (Item-count/1, Cellphone), (Item-count/1, Man-made-object), (Item-count/1, Furnishing))), (Background-view, (Paved-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Cellphone),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain))",
+    "coco_id": "23392",
+    "nsd_id": "10610"
+  },
+  "shared0130_nsd10908": {
+    "hed_short": "(Foreground-view, (Item-count/1, Furnishing)), (Background-view, (Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "548593",
+    "nsd_id": "10907"
+  },
+  "shared0131_nsd11160": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "549301",
+    "nsd_id": "11159"
+  },
+  "shared0132_nsd11334": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Walk, (Item-count/1, Man-made-object))), (Item-count/2, Animal), Terrain/Sand)), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Move/Move-body-part/Move-lower-extremity/Walk,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Sand)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "549830",
+    "nsd_id": "11333"
+  },
+  "shared0133_nsd11488": {
+    "hed_short": "(Foreground-view, ((Item-count/3, (Human, Body, Male, Agent-trait/Adult)), (Item-count/3, Laptop-computer), ((Item-count, High), Furnishing))), (Background-view, (Plant, Outdoors, Paved-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain))",
+    "coco_id": "26029",
+    "nsd_id": "11487"
+  },
+  "shared0134_nsd11522": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Away-from), Agent-trait/Adult)), (Walk, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Move/Move-body-part/Move-lower-extremity/Walk,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "550396",
+    "nsd_id": "11521"
+  },
+  "shared0135_nsd11567": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), Dirt-terrain)), (Background-view, (Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Dirt-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "288372",
+    "nsd_id": "11566"
+  },
+  "shared0136_nsd11618": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), (Item-count/1, Microphone))), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Microphone))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "26388",
+    "nsd_id": "11617"
+  },
+  "shared0137_nsd11636": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, Agent-trait/Adult)), (Item-count/2, (Human, Body, Male, Agent-trait/Adult)), (Item-count/1, Animal), (Item-count/1, Furnishing))), (Background-view, (Path, Plant, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Path,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "26443",
+    "nsd_id": "11635"
+  },
+  "shared0138_nsd11690": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Path), (Item-count/2, Boat), Natural-feature/Ocean)), (Background-view, (Building, Outdoors, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Vehicle/Boat),Item/Object/Natural-object/Natural-feature/Ocean)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban))",
+    "coco_id": "288751",
+    "nsd_id": "11689"
+  },
+  "shared0139_nsd11726": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Animal, Animal-agent)), Walk)), (Background-view, (Path, Uneven-terrain, Rocky-terrain, Grassy-terrain, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Animal,Agent/Animal-agent)),Action/Move/Move-body-part/Move-lower-extremity/Walk)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Path,Property/Environmental-property/Terrain/Uneven-terrain,Property/Environmental-property/Terrain/Rocky-terrain,Property/Environmental-property/Terrain/Grassy-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "26702",
+    "nsd_id": "11725"
+  },
+  "shared0140_nsd11797": {
+    "hed_short": "(Foreground-view, (Item-count/4, Furnishing)), (Background-view, (Indoors, Plant, Animal))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Biological-item/Organism/Plant,Item/Biological-item/Organism/Animal))",
+    "coco_id": "551164",
+    "nsd_id": "11796"
+  },
+  "shared0141_nsd11828": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object)), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "26981",
+    "nsd_id": "11827"
+  },
+  "shared0142_nsd11838": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Vehicle), (Item-count/1, Path), (Item-count/1, Furnishing))), (Background-view, (Grassy-terrain, Field, Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "27002",
+    "nsd_id": "11837"
+  },
+  "shared0143_nsd11845": {
+    "hed_short": "(Foreground-view, (Item-count/2, Furnishing)), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "27030",
+    "nsd_id": "11844"
+  },
+  "shared0144_nsd11933": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, Female, (Face, Away-from), Agent-trait/Adult)), (Item-count/1, (Human, Body, Male, Agent-trait/Adult)), ((Item-count, High), Furnishing))), (Background-view, (Outdoors, Paved-terrain, Plant, Furnishing, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Furnishing,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "354070",
+    "nsd_id": "11932"
+  },
+  "shared0145_nsd11943": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Furnishing)), (Background-view, (Room, Indoors, Entrance))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Building/Entrance))",
+    "coco_id": "27298",
+    "nsd_id": "11942"
+  },
+  "shared0146_nsd11953": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Bicycle), Grassy-terrain, (Item-count/1, Path), (Item-count/1, Man-made-object))), (Background-view, (Outdoors, Entrance, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Bicycle),Property/Environmental-property/Terrain/Grassy-terrain,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building/Entrance,Item/Object/Man-made-object/Building))",
+    "coco_id": "289460",
+    "nsd_id": "11952"
+  },
+  "shared0147_nsd12066": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing))), (Background-view, ((Human, Body, Agent-trait/Adult), Furnishing, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors))",
+    "coco_id": "289791",
+    "nsd_id": "12065"
+  },
+  "shared0148_nsd12076": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), Grassy-terrain, Field)), (Background-view, (Animal, Outdoors,Plant, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Animal,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building))",
+    "coco_id": "27665",
+    "nsd_id": "12075"
+  },
+  "shared0149_nsd12215": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Aircraft)), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle/Aircraft)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "290192",
+    "nsd_id": "12214"
+  },
+  "shared0150_nsd12309": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "552589",
+    "nsd_id": "12308"
+  },
+  "shared0151_nsd12488": {
+    "hed_short": "(Foreground-view, (Item-count/1, Aircraft)), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "553150",
+    "nsd_id": "12487"
+  },
+  "shared0152_nsd12496": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "553166",
+    "nsd_id": "12495"
+  },
+  "shared0153_nsd12635": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/2, Furnishing))), (Background-view, (Furnishing, Document))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Document))",
+    "coco_id": "553586",
+    "nsd_id": "12634"
+  },
+  "shared0154_nsd12686": {
+    "hed_short": "(Foreground-view, (Item-count/1, Man-made-object)), (Background-view, (Building, Grassy-terrain, Outdoors, Cone))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors,Item/Object/Geometric-object/3D-shape/Cone))",
+    "coco_id": "291560",
+    "nsd_id": "12685"
+  },
+  "shared0155_nsd12797": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Outdoors, Plant, Sloped-terrain, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Sloped-terrain,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "29730",
+    "nsd_id": "12796"
+  },
+  "shared0156_nsd12799": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), Rocky-terrain)), (Background-view, (Outdoors, Rocky-terrain, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Rocky-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Rocky-terrain,Item/Biological-item/Organism/Plant))",
+    "coco_id": "29732",
+    "nsd_id": "12798"
+  },
+  "shared0157_nsd12923": {
+    "hed_short": "(Foreground-view, ((((Item-count, High), ((Human, Human-agent), Body, Agent-trait/Child)), (Play, ((Item-count, High), Man-made-object/Toy))), ((Item-count, High), (Human,Body, Agent-trait/Adult)), Grassy-terrain, Field)),(Background-view, (Outdoors, Building, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Child)),(Action/Perform/Play,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy))),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "30109",
+    "nsd_id": "12922"
+  },
+  "shared0158_nsd12938": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Desktop-computer), (Item-count/1, Keyboard), (Item-count/1, Computer-mouse), (Item-count/2, Loudspeaker), (Item-count/1, Furnishing), (Item-count/1, Man-made-object))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/IO-device/Output-device/Auditory-device/Loudspeaker),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "30148",
+    "nsd_id": "12937"
+  },
+  "shared0159_nsd13139": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Older-adult)), (Item-count/1, Furnishing))), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Older-adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "292845",
+    "nsd_id": "13138"
+  },
+  "shared0160_nsd13231": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), Grassy-terrain, (Item-count/1, Man-made-object/Toy))), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "293130",
+    "nsd_id": "13230"
+  },
+  "shared0161_nsd13313": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Plant), (Item-count/1, Book), (Item-count/3, Furnishing))), (Background-view, (Outdoors, Plant, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Document/Book),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "293368",
+    "nsd_id": "13312"
+  },
+  "shared0162_nsd13315": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Adolescent)), (Item-count/1, Furnishing))), (Background-view, (Indoors, Room))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adolescent)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Building/Room))",
+    "coco_id": "293372",
+    "nsd_id": "13314"
+  },
+  "shared0163_nsd13614": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Away-from), Agent-trait/Adolescent)), (Play, (Item-count/2, Man-made-object/Toy))), (Item-count/1, Word))), (Background-view, (Outdoors, Paved-terrain, Car))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Man-made-object/Vehicle/Car))",
+    "coco_id": "32134",
+    "nsd_id": "13613"
+  },
+  "shared0164_nsd13654": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Female, (Face, Towards), Agent-trait/Adult)), (Action/Ride, (Item-count/1, (Animal, Animal-agent))), Run),  (Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), Dirt-terrain)), (Background-view, (Grassy-terrain, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent))),Action/Move/Move-body-part/Move-lower-extremity/Run),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),Property/Environmental-property/Terrain/Dirt-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "556542",
+    "nsd_id": "13653"
+  },
+  "shared0165_nsd13663": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Furnishing)), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "32275",
+    "nsd_id": "13662"
+  },
+  "shared0166_nsd13721": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Vehicle), ((Item-count, High), Word))), (Background-view, (Road, Building, Outdoors, Paved-terrain, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Road,Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Urban))",
+    "coco_id": "556748",
+    "nsd_id": "13720"
+  },
+  "shared0167_nsd13847": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Vehicle), ((Item-count, High), (Human, Body)), ((Item-count, High), Word))), (Background-view, (Road, Car, Vehicle, Outdoors, Paved-terrain, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Road,Item/Object/Man-made-object/Vehicle/Car,Item/Object/Man-made-object/Vehicle,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Biological-item/Organism/Plant))",
+    "coco_id": "32809",
+    "nsd_id": "13846"
+  },
+  "shared0168_nsd14111": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Furnishing), (Item-count/4, Box))), (Background-view, (Plant, Paved-terrain, Outdoors, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Geometric-object/3D-shape/Box))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban))",
+    "coco_id": "557848",
+    "nsd_id": "14110"
+  },
+  "shared0169_nsd14122": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, Agent-trait/Adult)), (Item-count/1, Cart), ((Item-count/1, (Animal, Animal-agent)), (Walk, (Item-count/1, Road))))), (Background-view, (Outdoors, Rural, Natural-feature/Sky, Grassy-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Cart),((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent)),(Action/Move/Move-body-part/Move-lower-extremity/Walk,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Terrain/Grassy-terrain))",
+    "coco_id": "557886",
+    "nsd_id": "14121"
+  },
+  "shared0170_nsd14166": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Building), (Item-count/1, Clock-face), (Item-count/2, Plant))), (Background-view, (Building, Outdoors, Natural-feature/Sky, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban))",
+    "coco_id": "33727",
+    "nsd_id": "14165"
+  },
+  "shared0171_nsd14180": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Towards), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), ((Item-count/1, ((Human, Human-agent), Body, Male)), Play), Grassy-terrain)), (Background-view, (Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male)),Action/Perform/Play),Property/Environmental-property/Terrain/Grassy-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "33764",
+    "nsd_id": "14179"
+  },
+  "shared0172_nsd14444": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), Grassy-terrain, Field, ((Item-count, High), Animal), (Item-count/1, Hill))), (Background-view, (Outdoors, Plant, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/Hill))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural))",
+    "coco_id": "558822",
+    "nsd_id": "14443"
+  },
+  "shared0173_nsd14529": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Clock-face), ((Item-count, High), Furnishing))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "559816",
+    "nsd_id": "14528"
+  },
+  "shared0174_nsd14568": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean, Animal))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean,Item/Biological-item/Organism/Animal))",
+    "coco_id": "559145",
+    "nsd_id": "14567"
+  },
+  "shared0175_nsd14595": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), ((Item-count, High), Plant))), (Background-view, (Grassy-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "559225",
+    "nsd_id": "14594"
+  },
+  "shared0176_nsd14611": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/3, Word))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "297154",
+    "nsd_id": "14610"
+  },
+  "shared0177_nsd14645": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object)), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "573830",
+    "nsd_id": "14644"
+  },
+  "shared0178_nsd14794": {
+    "hed_short": "(Foreground-view, (Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult))), (Background-view, (Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "355458",
+    "nsd_id": "14793"
+  },
+  "shared0179_nsd14809": {
+    "hed_short": "(Foreground-view, (Item-count/1, Assistive-device)), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "559958",
+    "nsd_id": "14808"
+  },
+  "shared0180_nsd14821": {
+    "hed_short": "(Foreground-view, (((Item-count/2, ((Human, Human-agent), Body, Female, (Face, Towards), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), Grassy-terrain, Field)), (Background-view, (Outdoors, Building, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/2,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "297844",
+    "nsd_id": "14820"
+  },
+  "shared0181_nsd14899": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), Terrain/Sand)), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Sand)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "35927",
+    "nsd_id": "14898"
+  },
+  "shared0182_nsd14932": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), Grassy-terrain)), (Background-view, (Outdoors, Rural, Plant, Hill, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),Property/Environmental-property/Terrain/Grassy-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Hill,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "298170",
+    "nsd_id": "14931"
+  },
+  "shared0183_nsd15004": {
+    "hed_short": "(Foreground-view, (Item-count/2, Furnishing)),(Background-view, (Room, Indoors, Assistive-device))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Device/Assistive-device))",
+    "coco_id": "298395",
+    "nsd_id": "15003"
+  },
+  "shared0184_nsd15026": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Outdoors, Plant, Sloped-terrain, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Rural))",
+    "coco_id": "6053",
+    "nsd_id": "15025"
+  },
+  "shared0185_nsd15129": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Agent-trait/Newborn)), (Item-count/1, Man-made-object/Toy))), (Background-view, (Indoors, Keyboard))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Newborn)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard))",
+    "coco_id": "36589",
+    "nsd_id": "15128"
+  },
+  "shared0186_nsd15365": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Man-made-object), (Item-count/1, Sculpture))), (Background-view, (Building, Natural-feature/Sky, Urban, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Sculpture))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Item/Object/Man-made-object))",
+    "coco_id": "37358",
+    "nsd_id": "15364"
+  },
+  "shared0187_nsd15493": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Car), (Item-count/4, Vehicle), (Item-count/3, (Human, Body, Agent-trait/Adult)), (Item-count/1, Road))), (Background-view, (Paved-terrain, Plant, Outdoors, Mountain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Mountain))",
+    "coco_id": "37779",
+    "nsd_id": "15492"
+  },
+  "shared0188_nsd15507": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Animal), Grassy-terrain)), (Background-view, (Building, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors))",
+    "coco_id": "37823",
+    "nsd_id": "15506"
+  },
+  "shared0189_nsd15794": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), (Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Adult)))), (Background-view, (Natural-feature/Sky, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "300881",
+    "nsd_id": "15793"
+  },
+  "shared0190_nsd15820": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Grassy-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "38801",
+    "nsd_id": "15819"
+  },
+  "shared0191_nsd15940": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), Grassy-terrain, (Item-count/2, Furnishing))), (Background-view, (Path, Road, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Path,Item/Object/Man-made-object/Navigational-object/Road,Property/Environmental-property/Outdoors))",
+    "coco_id": "39196",
+    "nsd_id": "15939"
+  },
+  "shared0192_nsd16064": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), Sloped-terrain)), (Background-view, (Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),Property/Environmental-property/Terrain/Sloped-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "225054",
+    "nsd_id": "16063"
+  },
+  "shared0193_nsd16253": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing), ((Item-count, High), Photograph))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Media/Visualization/Image/Photograph))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "564465",
+    "nsd_id": "16252"
+  },
+  "shared0194_nsd16345": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Vehicle), (Item-count/1, Road))), (Background-view, (Car, Grassy-terrain, Plant, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Vehicle/Car,Property/Environmental-property/Terrain/Grassy-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "302588",
+    "nsd_id": "16344"
+  },
+  "shared0195_nsd16422": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "40685",
+    "nsd_id": "16421"
+  },
+  "shared0196_nsd16467": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, Female, (Face, Away-from), Agent-trait/Adult)), ((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing))), (Background-view, (Outdoors, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Urban))",
+    "coco_id": "574784",
+    "nsd_id": "16466"
+  },
+  "shared0197_nsd16617": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), ((Item-count, High), Plant))), (Background-view, (Room, Indoors, Entrance))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Building/Entrance))",
+    "coco_id": "303392",
+    "nsd_id": "16616"
+  },
+  "shared0198_nsd16636": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Car), (Item-count/1, Vehicle), ((Item-count, High), Word), (Item-count/1, Road))), (Background-view, (Path, Plant, Outdoors, Car))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Path,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Vehicle/Car))",
+    "coco_id": "303436",
+    "nsd_id": "16635"
+  },
+  "shared0199_nsd16656": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Animal), Grassy-terrain)), (Background-view, (Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "565652",
+    "nsd_id": "16655"
+  },
+  "shared0200_nsd16703": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), ((Item-count, High), Plant), (Item-count/1, Path))), (Background-view, (Outdoors, Building, Plant, Composite-terrain, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Composite-terrain,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "565834",
+    "nsd_id": "16702"
+  },
+  "shared0201_nsd16724": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, Male, Agent-trait/Adult)), (Item-count/1, Car), Terrain/Sand)), (Background-view, (Building, Man-made-object/Toy, Outdoors, Natural-feature/Sky, Rural, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car),Property/Environmental-property/Terrain/Sand)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Toy,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "41606",
+    "nsd_id": "16723"
+  },
+  "shared0202_nsd16824": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body, Agent-trait/Adult)), ((Item-count, High), Man-made-object/Toy), (Item-count/1, Plant))), (Background-view, (Outdoors, Plant, Mountain, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Mountain,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "566201",
+    "nsd_id": "16823"
+  },
+  "shared0203_nsd16842": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Vehicle), ((Item-count, High), (Human, Body, Agent-trait/Adult)), (Item-count/1, Road))), (Background-view, (Mountain, Building, Plant, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Mountain,Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "566261",
+    "nsd_id": "16841"
+  },
+  "shared0204_nsd16866": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Sloped-terrain, Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "304187",
+    "nsd_id": "16865"
+  },
+  "shared0205_nsd16869": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Animal), Rocky-terrain)), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Rocky-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "566341",
+    "nsd_id": "16868"
+  },
+  "shared0206_nsd16918": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/2, Furnishing))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "263276",
+    "nsd_id": "16917"
+  },
+  "shared0207_nsd17049": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Road), (Item-count/2, Man-made-object))), (Background-view, (Building, Plant, Outdoors, Urban, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "42578",
+    "nsd_id": "17048"
+  },
+  "shared0208_nsd17231": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Clock-face), (Item-count/1, Roof), (Item-count/1, Plant))), (Background-view, (Outdoors, Car, Plant, Natural-feature/Sky, Urban, Building, (Human, Body, Agent-trait/Adult)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Roof),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Vehicle/Car,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)))",
+    "coco_id": "43150",
+    "nsd_id": "17230"
+  },
+  "shared0209_nsd17239": {
+    "hed_short": "(Foreground-view, (Item-count/1, Clock-face)), (Background-view, (Building, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors))",
+    "coco_id": "43176",
+    "nsd_id": "17238"
+  },
+  "shared0210_nsd17370": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body, Male, Agent-trait/Adult)), ((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing), (Item-count/1, Pen))), (Background-view, (Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device/Writing-device/Pen))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "305685",
+    "nsd_id": "17369"
+  },
+  "shared0211_nsd17375": {
+    "hed_short": "(Foreground-view, ((Item-count/2, 2D-shape), (Item-count/1, Word), (Item-count/1, Character))), (Background-view, (Plant, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Geometric-object/2D-shape),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "567837",
+    "nsd_id": "17374"
+  },
+  "shared0212_nsd17451": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), (Item-count/1, Word), Dirt-terrain)), (Background-view, (Outdoors, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),Property/Environmental-property/Terrain/Dirt-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "43776",
+    "nsd_id": "17450"
+  },
+  "shared0213_nsd17464": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Train), Rocky-terrain, ((Item-count, High), Character))), (Background-view, (Natural-feature/Sky, Urban, Building, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle/Train),Property/Environmental-property/Terrain/Rocky-terrain,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors))",
+    "coco_id": "43815",
+    "nsd_id": "17463"
+  },
+  "shared0214_nsd17486": {
+    "hed_short": "(Background-view, (Furnishing, Room, Indoors, Photograph))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Media/Visualization/Image/Photograph))",
+    "coco_id": "306031",
+    "nsd_id": "17485"
+  },
+  "shared0215_nsd17550": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Furnishing)), (Background-view, (Photograph, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Media/Visualization/Image/Photograph,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "306249",
+    "nsd_id": "17549"
+  },
+  "shared0216_nsd17596": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/2, Word))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "225829",
+    "nsd_id": "17595"
+  },
+  "shared0217_nsd17777": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Female, Human, Body, Agent-trait/Adult)), (Item-count/3, (Human, Body, Agent-trait/Adult, Male)), (Item-count/1, Path), (Item-count/1, Furnishing))), (Background-view, (Grassy-terrain, Outdoors, Sculpture, Building, Plant, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Property/Agent-property/Agent-trait/Sex/Female,Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult,Property/Agent-property/Agent-trait/Sex/Male)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Media/Visualization/Sculpture,Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "306988",
+    "nsd_id": "17776"
+  },
+  "shared0218_nsd17795": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "569196",
+    "nsd_id": "17794"
+  },
+  "shared0219_nsd17935": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing), (Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Adult)), (Item-count/3, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)))), (Background-view, (Indoors, Furnishing, Photograph, Icon))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Media/Visualization/Image/Photograph,Item/Object/Man-made-object/Media/Visualization/Image/Icon))",
+    "coco_id": "219735",
+    "nsd_id": "17934"
+  },
+  "shared0220_nsd17943": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object)), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "569645",
+    "nsd_id": "17942"
+  },
+  "shared0221_nsd18269": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, (Face, Away-from), Male, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy))), ((Item-count/1, ((Human, Human-agent), Body, (Face, Away-from), Female, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy))), (Item-count/1, (Human, Body, (Face, Away-from), Male, Agent-trait/Adult)), (Item-count/1, Ingestible-object), (Item-count/1, Furnishing))), (Background-view, (Indoors, Furnishing, Room))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room))",
+    "coco_id": "575701",
+    "nsd_id": "18268"
+  },
+  "shared0222_nsd18435": {
+    "hed_short": "(Background-view, ((Item-count/2, Clock-face), Grassy-terrain, ((Item-count, High), Plant))), (Background-view, (Outdoors, Rural, Natural-feature/Sky, River, Mountain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face),Property/Environmental-property/Terrain/Grassy-terrain,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Natural-object/Natural-feature/River,Item/Object/Natural-object/Natural-feature/Mountain))",
+    "coco_id": "308950",
+    "nsd_id": "18434"
+  },
+  "shared0223_nsd18484": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Grassy-terrain, Field, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors))",
+    "coco_id": "309135",
+    "nsd_id": "18483"
+  },
+  "shared0224_nsd18506": {
+    "hed_short": "(Foreground-view, ((Item-count/2, ((Human, Human-agent), Body, (Face, Away-from), Male, Agent-trait/Adult)), (Bite, (Item-count/1, Ingestible-object))))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Move/Move-body-part/Move-face/Bite,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Ingestible-object))))",
+    "coco_id": "309192",
+    "nsd_id": "18505"
+  },
+  "shared0225_nsd18536": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), ((Item-count, High), Plant), Grassy-terrain, Field)), (Background-view, (Plant, Outdoors, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "47172",
+    "nsd_id": "18535"
+  },
+  "shared0226_nsd18544": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body)), (Item-count/1, Man-made-object))), (Background-view, (Plant, Building, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors))",
+    "coco_id": "571499",
+    "nsd_id": "18543"
+  },
+  "shared0227_nsd18691": {
+    "hed_short": "(Foreground-view, (Item-count/2, Man-made-object)), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "47638",
+    "nsd_id": "18690"
+  },
+  "shared0228_nsd18797": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), (Item-count/1, Road), (Item-count/1, Vehicle))), (Background-view, (Plant, Grassy-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "572215",
+    "nsd_id": "18796"
+  },
+  "shared0229_nsd19075": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Rocky-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Rocky-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "310870",
+    "nsd_id": "19074"
+  },
+  "shared0230_nsd19182": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/2, Furnishing), (Item-count/2, Assistive-device))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Assistive-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "573337",
+    "nsd_id": "19181"
+  },
+  "shared0231_nsd19200": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), Rocky-terrain)), (Background-view, (Plant, Natural-feature/Sky, Man-made-object, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),Property/Environmental-property/Terrain/Rocky-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object,Property/Environmental-property/Outdoors))",
+    "coco_id": "270325",
+    "nsd_id": "19199"
+  },
+  "shared0232_nsd19201": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), Rocky-terrain)), (Background-view, (Outdoors, Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),Property/Environmental-property/Terrain/Rocky-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "311232",
+    "nsd_id": "19200"
+  },
+  "shared0233_nsd19293": {
+    "hed_short": "(Foreground-view, (Item-count/2, Furnishing)), (Background-view, (Room, Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "532520",
+    "nsd_id": "19292"
+  },
+  "shared0234_nsd19437": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Away-from), Agent-trait/Adult)), (Item-count/1, Man-made-object), (Item-count/1, Road))), (Background-view, (Car, Building, Plant, Outdoors, Urban, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Vehicle/Car,Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Man-made-object))",
+    "coco_id": "312003",
+    "nsd_id": "19436"
+  },
+  "shared0235_nsd19574": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Truck), (Item-count/1, Road))), (Background-view, (Plant, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Truck),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "50256",
+    "nsd_id": "19573"
+  },
+  "shared0236_nsd19643": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, (Face, Away-from), Agent-trait/Adult)), ((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Away-from), Agent-trait/Adult)), (Operate, (Item-count/1, Man-made-object))))), (Background-view, (Indoors, Room))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Operate,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Building/Room))",
+    "coco_id": "574760",
+    "nsd_id": "19642"
+  },
+  "shared0237_nsd19673": {
+    "hed_short": "(Foreground-view, ((Item-count/3, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/4, Man-made-object/Toy)))), (Background-view, (Sloped-terrain, Plant, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "95809",
+    "nsd_id": "19672"
+  },
+  "shared0238_nsd19691": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (River, Outdoors, Dirt-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/River,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Dirt-terrain))",
+    "coco_id": "50624",
+    "nsd_id": "19690"
+  },
+  "shared0239_nsd19934": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body)), (Item-count/1, Boat), (Item-count/1, River))), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Boat),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "313480",
+    "nsd_id": "19933"
+  },
+  "shared0240_nsd20055": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult, Male)), (Play, (Item-count/1, Man-made-object/Toy))), (Item-count/1, (Human, Body, Female, Agent-trait/Adult)))), (Background-view, (Rocky-terrain, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult,Property/Agent-property/Agent-trait/Sex/Male)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Rocky-terrain,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "575971",
+    "nsd_id": "20054"
+  },
+  "shared0241_nsd20065": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Furnishing), ((Item-count, High), Clothing))), (Background-view, (Furnishing, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Clothing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors))",
+    "coco_id": "576011",
+    "nsd_id": "20064"
+  },
+  "shared0242_nsd20081": {
+    "hed_short": "(Background-view, (Animal, Grassy-terrain, Field, River, Outdoors, Mountain, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Animal,Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Object/Natural-object/Natural-feature/River,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Mountain,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "51774",
+    "nsd_id": "20080"
+  },
+  "shared0243_nsd20207": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), Terrain/Sand)), (Background-view, (Outdoors, (Human, Body), Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),Property/Environmental-property/Terrain/Sand)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "560396",
+    "nsd_id": "20206"
+  },
+  "shared0244_nsd20224": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy))), Sloped-terrain)), (Background-view, (Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),Property/Environmental-property/Terrain/Sloped-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "314379",
+    "nsd_id": "20223"
+  },
+  "shared0245_nsd20266": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, (Face, Towards), Agent-trait/Child)), (Item-count/1, Man-made-object/Toy))), (Background-view, (Paved-terrain, Building, Car, Outdoors, Urban, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Vehicle/Car,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "52348",
+    "nsd_id": "20265"
+  },
+  "shared0246_nsd20308": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body)), (Item-count/1, Boat), (Item-count/2, Furnishing))), (Background-view, (Building, Natural-feature/Ocean, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Boat),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "576749",
+    "nsd_id": "20307"
+  },
+  "shared0247_nsd20443": {
+    "hed_short": "(Foreground-view, (Item-count/1, Vehicle)), (Background-view, (Building, Car, Road, Plant, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Vehicle/Car,Item/Object/Man-made-object/Navigational-object/Road,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "576789",
+    "nsd_id": "20442"
+  },
+  "shared0248_nsd20634": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/3, Furnishing))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "455691",
+    "nsd_id": "20633"
+  },
+  "shared0249_nsd20651": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Towards), Agent-trait/Adolescent)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view,(Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "577817",
+    "nsd_id": "20650"
+  },
+  "shared0250_nsd20703": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, Agent-trait/Adolescent)), (Item-count/1, Man-made-object/Toy))), (Background-view, (Paved-terrain, Outdoors, Natural-feature/Sky, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adolescent)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Item/Biological-item/Organism/Plant))",
+    "coco_id": "577964",
+    "nsd_id": "20702"
+  },
+  "shared0251_nsd20739": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Dirt-terrain, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Dirt-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "53778",
+    "nsd_id": "20738"
+  },
+  "shared0252_nsd20778": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Assistive-device), ((Item-count, High), Furnishing))), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "578169",
+    "nsd_id": "20777"
+  },
+  "shared0253_nsd20821": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Agent-trait/Adult)), (Item-count/2, Man-made-object/Toy))), (Background-view, (Outdoors, Plant, Rural, Sloped-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural,Property/Environmental-property/Terrain/Sloped-terrain))",
+    "coco_id": "54001",
+    "nsd_id": "20820"
+  },
+  "shared0254_nsd21109": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors, Natural-feature/Sky, Building, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object/Building,Property/Environmental-property/Urban))",
+    "coco_id": "317061",
+    "nsd_id": "21108"
+  },
+  "shared0255_nsd21193": {
+    "hed_short": "(Foreground-view, (Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)))",
+    "coco_id": "55184",
+    "nsd_id": "21192"
+  },
+  "shared0256_nsd21195": {
+    "hed_short": "(Foreground-view, (Item-count/1, Furnishing)), (Background-view, (Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "9199",
+    "nsd_id": "21194"
+  },
+  "shared0257_nsd21198": {
+    "hed_short": "(Foreground-view, ((Item-count/3, (Human, Body, Agent-trait/Adult)), (Item-count/1, Boat), (Item-count/1, River))), (Background-view, (Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Boat),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "55206",
+    "nsd_id": "21197"
+  },
+  "shared0258_nsd21219": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Away-from), Female, Agent-trait/Adult)), (Item-count/1, Furnishing))), (Background-view, ((Human, Body, Agent-trait/Adult), Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Property/Environmental-property/Indoors))",
+    "coco_id": "55294",
+    "nsd_id": "21218"
+  },
+  "shared0259_nsd21254": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), (Item-count/1, Path), Field, Grassy-terrain)), (Background-view, (Outdoors, Natural-feature/Sky, Rural, Animal))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Terrain/Grassy-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural,Item/Biological-item/Organism/Animal))",
+    "coco_id": "55402",
+    "nsd_id": "21253"
+  },
+  "shared0260_nsd21280": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Outdoors, Plant, Sloped-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Sloped-terrain))",
+    "coco_id": "55514",
+    "nsd_id": "21279"
+  },
+  "shared0261_nsd21319": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Furnishing))), (Background-view, (Outdoors, Composite-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Composite-terrain))",
+    "coco_id": "317781",
+    "nsd_id": "21318"
+  },
+  "shared0262_nsd21509": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object)), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "318381",
+    "nsd_id": "21508"
+  },
+  "shared0263_nsd21527": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy))), Sloped-terrain)), (Background-view, (Outdoors, Plant, Mountain, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),Property/Environmental-property/Terrain/Sloped-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Mountain,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "318444",
+    "nsd_id": "21526"
+  },
+  "shared0264_nsd21554": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), (Item-count/2, Word), (Item-count/1, Plant))), (Background-view, (Outdoors, Building, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "1877",
+    "nsd_id": "21553"
+  },
+  "shared0265_nsd21602": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, Agent-trait/Adult)), (Item-count/1, Man-made-object))), (Background-view, (Path, Road, Paved-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Path,Item/Object/Man-made-object/Navigational-object/Road,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "580813",
+    "nsd_id": "21601"
+  },
+  "shared0266_nsd21704": {
+    "hed_short": "(Foreground-view, ((Item-count/2, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "56837",
+    "nsd_id": "21703"
+  },
+  "shared0267_nsd21951": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Adult)), (Item-count/2, Animal), (Item-count/1, Car))), (Background-view, (Grassy-terrain, Plant, Outdoors, Rural, Car))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Object/Man-made-object/Vehicle/Car))",
+    "coco_id": "57631",
+    "nsd_id": "21950"
+  },
+  "shared0268_nsd21990": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Away-from), Agent-trait/Adolescent)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "57796",
+    "nsd_id": "21989"
+  },
+  "shared0269_nsd22139": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), Grassy-terrain, Field, ((Item-count, High), Plant))), (Background-view, (Outdoors, Rural, Natural-feature/Sky, Plant, Hill))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Hill))",
+    "coco_id": "320533",
+    "nsd_id": "22138"
+  },
+  "shared0270_nsd22144": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Furnishing), ((Item-count, High), Plant))), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "58407",
+    "nsd_id": "22143"
+  },
+  "shared0271_nsd22156": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Outdoors, Plant, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building))",
+    "coco_id": "58465",
+    "nsd_id": "22155"
+  },
+  "shared0272_nsd22264": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Plant, Outdoors, Grassy-terrain, Field, Sloped-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Terrain/Sloped-terrain))",
+    "coco_id": "359337",
+    "nsd_id": "22263"
+  },
+  "shared0273_nsd22388": {
+    "hed_short": "(Foreground-view, ((Item-count/2, 2D-Shape), (Item-count/3, Word), (Item-count/1, Plant))), (Background-view, (Building, Clock-face, Outdoors, Urban, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Geometric-object/2D-shape),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "59321",
+    "nsd_id": "22387"
+  },
+  "shared0274_nsd22496": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "321902",
+    "nsd_id": "22495"
+  },
+  "shared0275_nsd22506": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), (Item-count/1, Car))), (Background-view, (Grassy-terrain, (Human, Body, Agent-trait/Older-adult), Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Older-adult),Property/Environmental-property/Outdoors))",
+    "coco_id": "403184",
+    "nsd_id": "22505"
+  },
+  "shared0276_nsd22516": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/1, Photograph))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Image/Photograph))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "322008",
+    "nsd_id": "22515"
+  },
+  "shared0277_nsd22524": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, (Face, Towards), Female, Agent-trait/Adult)), ((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "9983",
+    "nsd_id": "22523"
+  },
+  "shared0278_nsd22531": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/3, (Human, Body, Agent-trait/Adult)))), (Background-view, (Road, Paved-terrain, Natural-feature/Sky, Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Road,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "9987",
+    "nsd_id": "22530"
+  },
+  "shared0279_nsd22586": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Furnishing), ((Item-count, High), Clothing))), (Background-view, (Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Clothing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "322246",
+    "nsd_id": "22585"
+  },
+  "shared0280_nsd22588": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Towards), Agent-trait/Child)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Paved-terrain, Plant, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Child)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "322255",
+    "nsd_id": "22587"
+  },
+  "shared0281_nsd22773": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), Composite-terrain)), (Background-view, (Plant, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Composite-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "323010",
+    "nsd_id": "22772"
+  },
+  "shared0282_nsd22783": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/2, Clock-face), ((Item-count, High), Plant))), (Background-view, (Outdoors, Natural-feature/Sky, Urban, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building))",
+    "coco_id": "53842",
+    "nsd_id": "22782"
+  },
+  "shared0283_nsd22795": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Boat), (Item-count/1, Path), Natural-feature/Ocean)), (Background-view, (Hill, Building, Outdoors, Urban, Natural-feature/Sky, Boat))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle/Boat),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),Item/Object/Natural-object/Natural-feature/Ocean)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Hill,Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object/Vehicle/Boat))",
+    "coco_id": "359687",
+    "nsd_id": "22794"
+  },
+  "shared0284_nsd22810": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/1, Clock-face))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "323182",
+    "nsd_id": "22809"
+  },
+  "shared0285_nsd22846": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), (Item-count/1, Path))), (Background-view, (Grassy-terrain, Field, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "61174",
+    "nsd_id": "22845"
+  },
+  "shared0286_nsd22874": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Female, Agent-trait/Adult)), Walk), ((Item-count, High), Plant))), (Background-view, (Urban, Paved-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),Action/Move/Move-body-part/Move-lower-extremity/Walk),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Urban,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "323397",
+    "nsd_id": "22873"
+  },
+  "shared0287_nsd22880": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body)), (Item-count/2, Train), ((Item-count, High), Furnishing), (Item-count/1, Roof))), (Background-view, (Indoors, (Human, Body), Furnishing, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Vehicle/Train),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Roof))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Furnishing,Item/Biological-item/Organism/Plant))",
+    "coco_id": "61266",
+    "nsd_id": "22879"
+  },
+  "shared0288_nsd22887": {
+    "hed_short": "(Foreground-view, (Item-count/1, (Human, Body, (Face, Away-from), Female, Agent-trait/Adult))), (Background-view, (Car, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Vehicle/Car,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "61288",
+    "nsd_id": "22886"
+  },
+  "shared0289_nsd22958": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), Grassy-terrain, ((Item-count, High), Plant))), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),Property/Environmental-property/Terrain/Grassy-terrain,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "61559",
+    "nsd_id": "22957"
+  },
+  "shared0290_nsd22968": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Furnishing), (Item-count/2, Photograph))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Media/Visualization/Image/Photograph))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "534553",
+    "nsd_id": "22967"
+  },
+  "shared0291_nsd22994": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy))), Paved-terrain, (Item-count/3, Word))), (Background-view, (Outdoors, Clock-face, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),Property/Environmental-property/Terrain/Paved-terrain,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "490875",
+    "nsd_id": "22993"
+  },
+  "shared0292_nsd23037": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Outdoors, Plant, Grassy-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Grassy-terrain))",
+    "coco_id": "323970",
+    "nsd_id": "23036"
+  },
+  "shared0293_nsd23242": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, Male, (Item-count/1, Face, Towards), Agent-trait/Adult)), (Item-count/1, Animal), (Item-count/1, Laptop-computer))), (Background-view, (Book, Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Document/Book,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "62547",
+    "nsd_id": "23241"
+  },
+  "shared0294_nsd23493": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Away-from), Agent-trait/Adult)), (Item-count/2, (Human, Body, Male, Agent-trait/Adult)), ((Item-count, High), Ingestible-object), (Item-count/3, Furnishing), (Item-count/1, Path))), (Background-view, (Grassy-terrain, Outdoors, Plant, Building, Natural-feature/Sky, Urban, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "325710",
+    "nsd_id": "23492"
+  },
+  "shared0295_nsd23716": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, (Face, Towards), Agent-trait/Adult)), (Item-count/1, Man-made-object))), (Background-view, (Building, Outdoors, Paved-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain))",
+    "coco_id": "10743",
+    "nsd_id": "23715"
+  },
+  "shared0296_nsd23730": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Away-from), Agent-trait/Adult)), (Item-count/1, Word), (Item-count/1, Man-made-object/Toy))), (Background-view, (Grassy-terrain, Field, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors))",
+    "coco_id": "64534",
+    "nsd_id": "23729"
+  },
+  "shared0297_nsd23872": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Outdoors, Plant, Natural-feature/Sky, (Human, Body), Man-made-object/Toy))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Toy))",
+    "coco_id": "65012",
+    "nsd_id": "23871"
+  },
+  "shared0298_nsd23877": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Box), (Item-count/3, Furnishing), ((Item-count, High), Plant))), (Background-view, ((Human, Body, Agent-trait/Adult), Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Geometric-object/3D-shape/Box),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "65029",
+    "nsd_id": "23876"
+  },
+  "shared0299_nsd23884": {
+    "hed_short": "(Foreground-view, (Item-count/2, Furnishing)), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "327191",
+    "nsd_id": "23883"
+  },
+  "shared0300_nsd23994": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Away-from), Agent-trait/Adult)), (Item-count/1, (Human, Body, Agent-trait/Adult)), (Item-count/1, Animal), ((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing))), (Background-view, (Paved-terrain, Urban, Man-made-object, Ingestible-object, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Urban,Item/Object/Man-made-object,Item/Object/Ingestible-object,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "65400",
+    "nsd_id": "23993"
+  },
+  "shared0301_nsd24203": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Furnishing))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "66253",
+    "nsd_id": "24202"
+  },
+  "shared0302_nsd24215": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), Composite-terrain)), (Background-view, (Outdoors, Animal, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Composite-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Animal,Item/Biological-item/Organism/Plant))",
+    "coco_id": "328454",
+    "nsd_id": "24214"
+  },
+  "shared0303_nsd24265": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, Agent-trait/Adolescent)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Paved-terrain, Outdoors, Plant, (Human, Body), Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "328628",
+    "nsd_id": "24264"
+  },
+  "shared0304_nsd24318": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Furnishing), (Item-count/1, Display-device), (Item-count/1, Tool))), (Background-view, (Plant, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Output-device/Display-device),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Tool))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "66696",
+    "nsd_id": "24317"
+  },
+  "shared0305_nsd24481": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), (Item-count/2, Man-made-object), (Item-count/3, Character))), (Background-view, (Outdoors, Grassy-terrain, Plant, (Human, Body), Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Item/Biological-item/Organism/Plant,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Property/Environmental-property/Rural))",
+    "coco_id": "67347",
+    "nsd_id": "24480"
+  },
+  "shared0306_nsd24518": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, (Face, Away-from), Agent-trait/Adult)), (Item-count/1, Animal))), (Background-view, (Rocky-terrain, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Rocky-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "281575",
+    "nsd_id": "24517"
+  },
+  "shared0307_nsd24531": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/2, Clothing))), (Background-view, (Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Clothing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "329641",
+    "nsd_id": "24530"
+  },
+  "shared0308_nsd24561": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Icon), (Item-count/2, 2D-Shape), (Item-count/1, Car), (Item-count/3, Road))), (Background-view, (Plant, Natural-feature/Sky, Car))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Image/Icon),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Geometric-object/2D-shape),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object/Vehicle/Car))",
+    "coco_id": "67623",
+    "nsd_id": "24560"
+  },
+  "shared0309_nsd24639": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "330084",
+    "nsd_id": "24638"
+  },
+  "shared0310_nsd24641": {
+    "hed_short": "(Foreground-view, (Item-count/3, Furnishing)), (Background-view, ((Human, Body), Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "330086",
+    "nsd_id": "24640"
+  },
+  "shared0311_nsd24650": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object))",
+    "coco_id": "67961",
+    "nsd_id": "24649"
+  },
+  "shared0312_nsd24740": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Furnishing)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing)))",
+    "coco_id": "68238",
+    "nsd_id": "24739"
+  },
+  "shared0313_nsd24741": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), ((Item-count, High), Plant))), (Background-view, (Grassy-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "11373",
+    "nsd_id": "24740"
+  },
+  "shared0314_nsd24788": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adolescent)), (Play, ((Item-count, High), Man-made-object/Toy))), (Item-count/1, Furnishing), (Item-count/1, Display-device))), (Background-view, (Room, Furnishing, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Output-device/Display-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors))",
+    "coco_id": "55090",
+    "nsd_id": "24787"
+  },
+  "shared0315_nsd24847": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Animal), Grassy-terrain, Field)), (Background-view, (Plant, Outdoors, Hill, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Hill,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "68623",
+    "nsd_id": "24846"
+  },
+  "shared0316_nsd25060": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Car), (Item-count/1, Road), ((Item-count, High), Word), ((Item-count, High), 2D-Shape), (Item-count/1, Building))), (Background-view, (Natural-feature/Sky, Urban, Car, Building, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Word),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Geometric-object/2D-shape),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Item/Object/Man-made-object/Vehicle/Car,Item/Object/Man-made-object/Building,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "246728",
+    "nsd_id": "25059"
+  },
+  "shared0317_nsd25092": {
+    "hed_short": "(Background-view, ((Item-count/1, (Human, Body, Male, (Face, Towards), Agent-trait/Adult)), (Item-count/1, Furnishing))), (Background-view, (Paved-terrain, Outdoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "69625",
+    "nsd_id": "25091"
+  },
+  "shared0318_nsd25112": {
+    "hed_short": "(Foreground-view, (((Item-count/1, (Animal, Animal-agent)), (Collide-with, (Item-count/1, (Animal, Animal-agent)))), Grassy-terrain, Field)), (Background-view, (Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent)),(Action/Perform/Collide-with,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent)))),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "69705",
+    "nsd_id": "25111"
+  },
+  "shared0319_nsd25206": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean, Mountain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Mountain))",
+    "coco_id": "332261",
+    "nsd_id": "25205"
+  },
+  "shared0320_nsd25251": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Furnishing), ((Item-count, High), Plant))), (Background-view, (Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "332448",
+    "nsd_id": "25250"
+  },
+  "shared0321_nsd25269": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Path))), (Background-view, (Composite-terrain, Building, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "332498",
+    "nsd_id": "25268"
+  },
+  "shared0322_nsd25285": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Car))), (Background-view, (Road, Grassy-terrain, Plant, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Road,Property/Environmental-property/Terrain/Grassy-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "70421",
+    "nsd_id": "25284"
+  },
+  "shared0323_nsd25288": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Furnishing), (Item-count/1, Man-made-object))), (Background-view, (Furnishing, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors))",
+    "coco_id": "332574",
+    "nsd_id": "25287"
+  },
+  "shared0324_nsd25319": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Plant))), (Background-view, (Outdoors, Rural, River, Rocky-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/River,Property/Environmental-property/Terrain/Rocky-terrain))",
+    "coco_id": "332692",
+    "nsd_id": "25318"
+  },
+  "shared0325_nsd25320": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/2, Furnishing))), (Background-view, (Room, Furnishing, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors))",
+    "coco_id": "2349",
+    "nsd_id": "25319"
+  },
+  "shared0326_nsd25372": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body, (Face, Away-from), Agent-trait/Adult)), ((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing))), (Background-view, (Indoors, Room))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Building/Room))",
+    "coco_id": "332875",
+    "nsd_id": "25371"
+  },
+  "shared0327_nsd25455": {
+    "hed_short": "(Foreground-view, (((Item-count/3, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy))), Dirt-terrain)), (Background-view, (Outdoors, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/3,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),Property/Environmental-property/Terrain/Dirt-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "333152",
+    "nsd_id": "25454"
+  },
+  "shared0328_nsd25571": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Ingestible-object), ((Item-count, High), Plant)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant)))",
+    "coco_id": "71429",
+    "nsd_id": "25570"
+  },
+  "shared0329_nsd25579": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Child)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Child)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "333615",
+    "nsd_id": "25578"
+  },
+  "shared0330_nsd25582": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), Sloped-terrain)), (Background-view, (Outdoors, Mountain, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),Property/Environmental-property/Terrain/Sloped-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Mountain,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "333629",
+    "nsd_id": "25581"
+  },
+  "shared0331_nsd25589": {
+    "hed_short": "(Background-view, (Urban, Road, Car, Vehicle, Truck, Building, Plant, Outdoors, Paved-terrain, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Urban,Item/Object/Man-made-object/Navigational-object/Road,Item/Object/Man-made-object/Vehicle/Car,Item/Object/Man-made-object/Vehicle,Item/Object/Man-made-object/Vehicle/Truck,Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "333654",
+    "nsd_id": "25588"
+  },
+  "shared0332_nsd25603": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Action/Ride, (Item-count/1, Vehicle))), ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), Walk), Grassy-terrain, Field)), (Background-view, (Outdoors, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle))),((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),Action/Move/Move-body-part/Move-lower-extremity/Walk),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "579906",
+    "nsd_id": "25602"
+  },
+  "shared0333_nsd25694": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, Agent-trait/Adult)), (Item-count/1, (Human, Body, Female, Agent-trait/Adult)), (Item-count/1, Animal))), (Background-view, (Uneven-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Uneven-terrain))",
+    "coco_id": "334011",
+    "nsd_id": "25693"
+  },
+  "shared0334_nsd25703": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), Grassy-terrain, Field)), (Background-view, (Mountain, Natural-feature/Sky, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Mountain,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "334048",
+    "nsd_id": "25702"
+  },
+  "shared0335_nsd25712": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Boat), (Item-count/2, (Human, Body), Agent-trait/Adult), (Item-count/1, River))), (Background-view, (Outdoors, Building, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Boat),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Property/Agent-property/Agent-trait/Adult),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building,Property/Environmental-property/Urban))",
+    "coco_id": "71927",
+    "nsd_id": "25711"
+  },
+  "shared0336_nsd25742": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object)), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "334208",
+    "nsd_id": "25741"
+  },
+  "shared0337_nsd25747": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adolescent)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Outdoors, Grassy-terrain, Plant, (Human, Body), Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Item/Biological-item/Organism/Plant,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "72095",
+    "nsd_id": "25746"
+  },
+  "shared0338_nsd25882": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), Paved-terrain)), (Background-view, (River, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Paved-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/River,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "334772",
+    "nsd_id": "25881"
+  },
+  "shared0339_nsd25907": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Furnishing), ((Item-count, High), Book), (Item-count/3, Man-made-object))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Document/Book),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "72715",
+    "nsd_id": "25906"
+  },
+  "shared0340_nsd25960": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Older-adult)), (Play, (Item-count/1, Man-made-object/Toy))), (Item-count/1, Cone))), (Background-view, (Paved-terrain, Outdoors, Road, Plant, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Older-adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Geometric-object/3D-shape/Cone))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Navigational-object/Road,Item/Biological-item/Organism/Plant,Property/Environmental-property/Urban))",
+    "coco_id": "335063",
+    "nsd_id": "25959"
+  },
+  "shared0341_nsd26120": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body, (Face, Away-from), Agent-trait/Adolescent)), ((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing))), (Background-view, (Furnishing, Indoors,  Room, Book, Photograph))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adolescent)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Building/Room,Item/Object/Man-made-object/Document/Book,Item/Object/Man-made-object/Media/Visualization/Image/Photograph))",
+    "coco_id": "492851",
+    "nsd_id": "26119"
+  },
+  "shared0342_nsd26128": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Desktop-computer), (Item-count/1, Keyboard), (Item-count/1, Computer-mouse), (Item-count/3, Furnishing))), (Background-view, (Room, Indoors, Photograph, Pen, Furnishing, Notebook))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Media/Visualization/Image/Photograph,Item/Object/Man-made-object/Device/Assistive-device/Writing-device/Pen,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Document/Notebook))",
+    "coco_id": "335688",
+    "nsd_id": "26127"
+  },
+  "shared0343_nsd26164": {
+    "hed_short": "(Foreground-view, ((Item-count/3, (Human, Body, Agent-trait/Adult)), ((Item-count, High), Man-made-object/Toy))), (Background-view, (Sloped-terrain, Plant, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "335824",
+    "nsd_id": "26163"
+  },
+  "shared0344_nsd26244": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors, Grassy-terrain, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Item/Biological-item/Organism/Plant))",
+    "coco_id": "73997",
+    "nsd_id": "26243"
+  },
+  "shared0345_nsd26293": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Furnishing), ((Item-count, High), Book))), (Background-view, (Room, Indoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Document/Book))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "281567",
+    "nsd_id": "26292"
+  },
+  "shared0346_nsd26308": {
+    "hed_short": "(Foreground-view, (((Item-count, High), ((Human, Human-agent), Body)), (Play, ((Item-count, High), Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body)),(Action/Perform/Play,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "336374",
+    "nsd_id": "26307"
+  },
+  "shared0347_nsd26352": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Plant))), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "74390",
+    "nsd_id": "26351"
+  },
+  "shared0348_nsd26373": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Path), (Item-count/4, Furnishing))), (Background-view, (Furnishing, (Human, Body, Agent-trait/Adult), Outdoors, Plant, Grassy-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Grassy-terrain))",
+    "coco_id": "74461",
+    "nsd_id": "26372"
+  },
+  "shared0349_nsd26436": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body)), ((Item-count, High), Man-made-object/Toy), Terrain/Sand)), (Background-view, (Outdoors, (Human, Body), Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy),Property/Environmental-property/Terrain/Sand)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "74714",
+    "nsd_id": "26435"
+  },
+  "shared0350_nsd26459": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Plant))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "74828",
+    "nsd_id": "26458"
+  },
+  "shared0351_nsd26599": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), Grassy-terrain, Field)), (Background-view, (Outdoors, Plant, Natural-feature/Sky, Rural, Animal))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural,Item/Biological-item/Organism/Animal))",
+    "coco_id": "337479",
+    "nsd_id": "26598"
+  },
+  "shared0352_nsd26721": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Desktop-computer), (Item-count/1, Keyboard), (Item-count/1, Computer-mouse), ((Item-count, High), Furnishing), ((Item-count, High), Photograph), (Item-count/1, Pen, Notebook))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Media/Visualization/Image/Photograph),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device/Writing-device/Pen,Item/Object/Man-made-object/Document/Notebook))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "274776",
+    "nsd_id": "26720"
+  },
+  "shared0353_nsd26781": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Vehicle), ((Item-count, High), Man-made-object/Toy))), (Background-view, ((Human, Body, Agent-trait/Adult), Building, Outdoors, Paved-terrain, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Urban))",
+    "coco_id": "338169",
+    "nsd_id": "26780"
+  },
+  "shared0354_nsd26896": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/1, Runway), (Item-count/2, Icon))), (Background-view, (Grassy-terrain, Car, Road, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Runway),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Media/Visualization/Image/Icon))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Man-made-object/Vehicle/Car,Item/Object/Man-made-object/Navigational-object/Road,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "76476",
+    "nsd_id": "26895"
+  },
+  "shared0355_nsd26910": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing), (Item-count/1, Word))), (Background-view, (Indoors, Room, (Human, Body, Agent-trait/Adult), Ingestible-object, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Building/Room,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Item/Object/Ingestible-object,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "338670",
+    "nsd_id": "26909"
+  },
+  "shared0356_nsd26972": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "12795",
+    "nsd_id": "26971"
+  },
+  "shared0357_nsd26991": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Man-made-object), Paved-terrain)), (Background-view, (Outdoors, Plant, (Human, Body, Female, Agent-trait/Adult)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object),Property/Environmental-property/Terrain/Paved-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)))",
+    "coco_id": "338987",
+    "nsd_id": "26990"
+  },
+  "shared0358_nsd27243": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Keyboard))), (Background-view, (Computer-mouse, Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "77870",
+    "nsd_id": "27242"
+  },
+  "shared0359_nsd27276": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "78000",
+    "nsd_id": "27275"
+  },
+  "shared0360_nsd27288": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Square), (Item-count/3, Word), (Item-count/3, Icon), (Item-count/1, Plant))), (Background-view, (Grassy-terrain, Field, Outdoors, Path,  Plant, (Human, Body, Agent-trait/Adult), Urban, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Geometric-object/2D-shape/Rectangle/Square),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Media/Visualization/Image/Icon),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Navigational-object/Path,Item/Biological-item/Organism/Plant,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "78042",
+    "nsd_id": "27287"
+  },
+  "shared0361_nsd27327": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, Agent-trait/Adult)), (Item-count/1, (Human, Body, Male, (Face, Away-from), Agent-trait/Adult)), (Item-count/1, Man-made-object), (Item-count/3, Word))), (Background-view, (Paved-terrain, Outdoors, Car, Building, Plant, Natural-feature/Sky, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Vehicle/Car,Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban))",
+    "coco_id": "340317",
+    "nsd_id": "27326"
+  },
+  "shared0362_nsd27436": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Car), (Item-count/1, Animal))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "340734",
+    "nsd_id": "27435"
+  },
+  "shared0363_nsd27569": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/2, Furnishing), ((Item-count, High), Assistive-device))), (Background-view, (Paved-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Device/Assistive-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "79111",
+    "nsd_id": "27568"
+  },
+  "shared0364_nsd27581": {
+    "hed_short": "(Foreground-view, (Item-count/3, Furnishing)), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "275335",
+    "nsd_id": "27580"
+  },
+  "shared0365_nsd27831": {
+    "hed_short": "(Foreground-view, (Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Adult))), (Background-view, (Furnishing, Room, Indoors, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object))",
+    "coco_id": "80084",
+    "nsd_id": "27830"
+  },
+  "shared0366_nsd27879": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Animal), Grassy-terrain)), (Background-view, (Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "80275",
+    "nsd_id": "27878"
+  },
+  "shared0367_nsd27973": {
+    "hed_short": "(Foreground-view, (Item-count/1, (Human, Body, Male, (Face, Away-from), Agent-trait/Adult))), (Background-view, (Indoors, Building, Furnishing, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Urban))",
+    "coco_id": "80619",
+    "nsd_id": "27972"
+  },
+  "shared0368_nsd28025": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/1, Runway), (Item-count/1, Icon), Grassy-terrain)), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Runway),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Image/Icon),Property/Environmental-property/Terrain/Grassy-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "8471",
+    "nsd_id": "28024"
+  },
+  "shared0369_nsd28069": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Dirt-terrain, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Dirt-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "80987",
+    "nsd_id": "28068"
+  },
+  "shared0370_nsd28097": {
+    "hed_short": "(Background-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "81105",
+    "nsd_id": "28096"
+  },
+  "shared0371_nsd28160": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "81365",
+    "nsd_id": "28159"
+  },
+  "shared0372_nsd28190": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Dirt-terrain, Plant, Outdoors, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Dirt-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building))",
+    "coco_id": "81474",
+    "nsd_id": "28189"
+  },
+  "shared0373_nsd28287": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Furnishing)), (Background-view, (Room, Indoors, Book, Plant, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Document/Book,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "81841",
+    "nsd_id": "28286"
+  },
+  "shared0374_nsd28304": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, Agent-trait/Adult)), (Item-count/1, Man-made-object), (Item-count/2, Furnishing), Terrain/Sand)), (Foreground-view, (Plant, Outdoors, Rural, (Human, Body, Agent-trait/Adult), (Human, Body, Agent-trait/Child)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),Property/Environmental-property/Terrain/Sand)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Child)))",
+    "coco_id": "46372",
+    "nsd_id": "28303"
+  },
+  "shared0375_nsd28320": {
+    "hed_short": "(Foreground-view, ((Item-count/3, (Human, Body, Agent-trait/Adult)), ((Item-count, High), Man-made-object/Toy))), (Background-view, (Outdoors, Sloped-terrain, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "81961",
+    "nsd_id": "28319"
+  },
+  "shared0376_nsd28326": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Action/Ride, (Item-count/1, (Animal, Animal-agent))), Walk)), (Background-view, (Grassy-terrain, Sloped-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent))),Action/Move/Move-body-part/Move-lower-extremity/Walk)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "81995",
+    "nsd_id": "28325"
+  },
+  "shared0377_nsd28342": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Furnishing), ((Item-count, High), Plant))), (Background-view, (Book, Man-made-object/Toy, Room, Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Document/Book,Item/Object/Man-made-object/Toy,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "450584",
+    "nsd_id": "28341"
+  },
+  "shared0378_nsd28350": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Away-from), Agent-trait/Adult)), (Item-count/1, Boat))), (Background-view, (River, Natural-feature/Sky, Outdoors, Urban, (Human, Body), Boat))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Boat))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/River,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Vehicle/Boat))",
+    "coco_id": "319517",
+    "nsd_id": "28349"
+  },
+  "shared0379_nsd28419": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Towards), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "569678",
+    "nsd_id": "28418"
+  },
+  "shared0380_nsd28488": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), (Item-count/1, Building))), (Background-view, (Natural-feature/Sky, Urban, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "82650",
+    "nsd_id": "28487"
+  },
+  "shared0381_nsd28525": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Car), (Item-count/2, Man-made-object), Paved-terrain)), (Background-view, (Terrain/Sand, Natural-feature/Ocean, Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Vehicle/Car),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object),Property/Environmental-property/Terrain/Paved-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sand,Item/Object/Natural-object/Natural-feature/Ocean,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "82770",
+    "nsd_id": "28524"
+  },
+  "shared0382_nsd28596": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors, Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "345149",
+    "nsd_id": "28595"
+  },
+  "shared0383_nsd28690": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Car), (Item-count/1, Road), (Item-count/1, Clock-face))), (Background-view, (Paved-terrain, Outdoors, Urban, Natural-feature/Sky, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle/Car),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object/Building))",
+    "coco_id": "83393",
+    "nsd_id": "28689"
+  },
+  "shared0384_nsd28746": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "345725",
+    "nsd_id": "28745"
+  },
+  "shared0385_nsd28752": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "345751",
+    "nsd_id": "28751"
+  },
+  "shared0386_nsd28756": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Aircraft)), (Background-view, (Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle/Aircraft)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "83632",
+    "nsd_id": "28755"
+  },
+  "shared0387_nsd28789": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/1, Entrance))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Entrance))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "83738",
+    "nsd_id": "28788"
+  },
+  "shared0388_nsd28899": {
+    "hed_short": "(Foreground-view, ((Item-count/3, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Outdoors, Grassy-terrain, Field))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field))",
+    "coco_id": "84174",
+    "nsd_id": "28898"
+  },
+  "shared0389_nsd28964": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Car))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "346583",
+    "nsd_id": "28963"
+  },
+  "shared0390_nsd29011": {
+    "hed_short": "(Foreground-view, (Item-count/4, Furnishing)), (Background-view, (Room, Indoors, Furnishing, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object))",
+    "coco_id": "346754",
+    "nsd_id": "29010"
+  },
+  "shared0391_nsd29022": {
+    "hed_short": "(Foreground-view, ((Item-count/3, (Human, Body, Agent-trait/Adult)), ((Item-count, High), Man-made-object/Toy))), (Background-view, (Sloped-terrain, Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "346795",
+    "nsd_id": "29021"
+  },
+  "shared0392_nsd29382": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), (Item-count/1, Path))), (Background-view, (Composite-terrain, Field, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors))",
+    "coco_id": "348204",
+    "nsd_id": "29381"
+  },
+  "shared0393_nsd29569": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Natural-feature/Ocean, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "86811",
+    "nsd_id": "29568"
+  },
+  "shared0394_nsd29661": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Furnishing), ((Item-count, High), Man-made-object))), (Background-view, (Room, Indoors, Furnishing, Plant, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object))",
+    "coco_id": "87126",
+    "nsd_id": "29660"
+  },
+  "shared0395_nsd29664": {
+    "hed_short": "(Foreground-view, (Item-count/3, Animal)), (Background-view, (Mountain, Grassy-terrain, Field, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Mountain,Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "87146",
+    "nsd_id": "29663"
+  },
+  "shared0396_nsd29681": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Man-made-object), (Item-count/1, Road), (Item-count/3, Icon))), (Background-view, (Outdoors, Natural-feature/Sky, Man-made-object, Urban, Building, Car))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Media/Visualization/Image/Icon))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Vehicle/Car))",
+    "coco_id": "349363",
+    "nsd_id": "29680"
+  },
+  "shared0397_nsd29712": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/3, Furnishing), (Item-count/3, Tool))), (Background-view, (Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Device/Tool))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "87334",
+    "nsd_id": "29711"
+  },
+  "shared0398_nsd29838": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Desktop-computer), (Item-count/1, Keyboard), (Item-count/1, Computer-mouse), (Item-count/1, Animal), (Item-count/1, Furnishing), (Item-count/1, Ingestible-object), (Item-count/1, Pen))), (Background-view, ((Human, Body), Room, Indoors, Book, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device/Writing-device/Pen))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Document/Book,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "87871",
+    "nsd_id": "29837"
+  },
+  "shared0399_nsd29887": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Road), (Item-count/1, Man-made-object), ((Item-count, High), Plant))), (Background-view, (Paved-terrain, Outdoors, Building, Urban, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "320508",
+    "nsd_id": "29886"
+  },
+  "shared0400_nsd29920": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Path), (Item-count/1, Furnishing))), (Background-view, (Paved-terrain, Outdoors, Plant, (Human, Body, Female), Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female),Property/Environmental-property/Urban))",
+    "coco_id": "350299",
+    "nsd_id": "29919"
+  },
+  "shared0401_nsd29981": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), ((Item-count, High), Character), (Item-count/1, Path))), (Background-view, (Outdoors, Building, Roof))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Character),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Building/Roof))",
+    "coco_id": "88414",
+    "nsd_id": "29980"
+  },
+  "shared0402_nsd30082": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Road), (Item-count/2, Car), (Item-count/1, Icon), (Item-count/3, Rectangle), (Item-count/1, Word), (Item-count/1, Character))), (Background-view, (Paved-terrain, Outdoors, Plant, Natural-feature/Sky, Urban, Car, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Vehicle/Car),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Image/Icon),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Geometric-object/2D-shape/Rectangle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Item/Object/Man-made-object/Vehicle/Car,Item/Object/Man-made-object))",
+    "coco_id": "88835",
+    "nsd_id": "30081"
+  },
+  "shared0403_nsd30374": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Furnishing), ((Item-count, High), Plant))), (Background-view, ((Human, Body), Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "89908",
+    "nsd_id": "30373"
+  },
+  "shared0404_nsd30396": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), Rocky-terrain)), (Background-view, (Outdoors, Natural-feature/Sky, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Rocky-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Item/Biological-item/Organism/Plant))",
+    "coco_id": "352129",
+    "nsd_id": "30395"
+  },
+  "shared0405_nsd30408": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Child)), Walk), (Item-count/1, Man-made-object/Toy))), (Background-view, (Grassy-terrain, Field, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Child)),Action/Move/Move-body-part/Move-lower-extremity/Walk),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors))",
+    "coco_id": "189765",
+    "nsd_id": "30407"
+  },
+  "shared0406_nsd30431": {
+    "hed_short": "(Foreground-view, (Item-count/1, Man-made-object)), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "352236",
+    "nsd_id": "30430"
+  },
+  "shared0407_nsd30564": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/3, Furnishing), ((Item-count, High), Word))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "352724",
+    "nsd_id": "30563"
+  },
+  "shared0408_nsd30602": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Car), (Item-count/1, Road), (Item-count/2, Man-made-object))), (Background-view, (Outdoors, Paved-terrain, Plant, Rectangle, Icon, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle/Car),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Biological-item/Organism/Plant,Item/Object/Geometric-object/2D-shape/Rectangle,Item/Object/Man-made-object/Media/Visualization/Image/Icon,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "352861",
+    "nsd_id": "30601"
+  },
+  "shared0409_nsd30633": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Car))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Vehicle/Car))",
+    "coco_id": "90827",
+    "nsd_id": "30632"
+  },
+  "shared0410_nsd30673": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), Grassy-terrain, Field)), (Background-view, (Outdoors, Plant, Rural, Natural-feature/Sky, Animal))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky,Item/Biological-item/Organism/Animal))",
+    "coco_id": "90994",
+    "nsd_id": "30672"
+  },
+  "shared0411_nsd30675": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Vehicle), (Item-count/1, Entrance))), (Background-view, (Paved-terrain, Outdoors, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Entrance))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building))",
+    "coco_id": "91005",
+    "nsd_id": "30674"
+  },
+  "shared0412_nsd30848": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), ((Item-count, High), Plant))), (Background-view, (Outdoors, Rural, Dirt-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Property/Environmental-property/Terrain/Dirt-terrain))",
+    "coco_id": "408492",
+    "nsd_id": "30847"
+  },
+  "shared0413_nsd30857": {
+    "hed_short": "(Foreground-view, (Item-count/2, Boat)), (Background-view, (Natural-feature/Ocean, Mountain, Outdoors, Urban, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Vehicle/Boat)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Mountain,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "364806",
+    "nsd_id": "30856"
+  },
+  "shared0414_nsd30888": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), Grassy-terrain)), (Background-view, (Plant, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "91784",
+    "nsd_id": "30887"
+  },
+  "shared0415_nsd30923": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing))), (Background-view, (Ingestible-object, Furnishing, Outdoors, Paved-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Ingestible-object,Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain))",
+    "coco_id": "354045",
+    "nsd_id": "30922"
+  },
+  "shared0416_nsd30936": {
+    "hed_short": "(Foreground-view, (Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult))), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "354095",
+    "nsd_id": "30935"
+  },
+  "shared0417_nsd30955": {
+    "hed_short": "(Foreground-view, ((Item-count/2, ((Human, Human-agent), Body, Female, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Indoors, Furnishing, Room))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room))",
+    "coco_id": "92001",
+    "nsd_id": "30954"
+  },
+  "shared0418_nsd31029": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, (Face, Away-from), Agent-trait/Adult)), (Item-count/1, Furnishing))), (Background-view, (Building, Paved-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "92221",
+    "nsd_id": "31028"
+  },
+  "shared0419_nsd31050": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing), (Item-count/2, Assistive-device))), (Background-view, (Ingestible-object, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Assistive-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Ingestible-object,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "92288",
+    "nsd_id": "31049"
+  },
+  "shared0420_nsd31065": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, Agent-trait/Child)), (Item-count/1, Man-made-object/Toy), (Item-count/1, Animal), Grassy-terrain, Field, (Item-count/1, River))), (Background-view, (Outdoors, Building, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant))",
+    "coco_id": "92353",
+    "nsd_id": "31064"
+  },
+  "shared0421_nsd31124": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/1, Plant), (Item-count/1, Man-made-object))), (Background-view, (Entrance, Plant, Furnishing, Man-made-object, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Entrance,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "354761",
+    "nsd_id": "31123"
+  },
+  "shared0422_nsd31234": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Furnishing), (Item-count/1, Desktop-Computer), (Item-count/1, Book))), (Background-view, (Photograph, Loudspeaker, Indoors, Room, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Document/Book))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Media/Visualization/Image/Photograph,Item/Object/Man-made-object/Device/IO-device/Output-device/Auditory-device/Loudspeaker,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Building/Room,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "59194",
+    "nsd_id": "31233"
+  },
+  "shared0423_nsd31350": {
+    "hed_short": "(Foreground-view, (Item-count/4, Furnishing)), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "355622",
+    "nsd_id": "31349"
+  },
+  "shared0424_nsd31447": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object)), (Background-view, (Assistive-device, Ingestible-object, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Device/Assistive-device,Item/Object/Ingestible-object,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "277778",
+    "nsd_id": "31446"
+  },
+  "shared0425_nsd31660": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, (Face, Towards), Male, Agent-trait/Child)), (Play, (Item-count/1, Man-made-object/Toy))), Paved-terrain)), (Background-view, (Outdoors, Plant, Building, Urban, (Human, Body, Agent-trait/Adolescent), Man-made-object/Toy))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Child)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),Property/Environmental-property/Terrain/Paved-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building,Property/Environmental-property/Urban,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adolescent),Item/Object/Man-made-object/Toy))",
+    "coco_id": "356771",
+    "nsd_id": "31659"
+  },
+  "shared0426_nsd31748": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Away-from), Agent-trait/Adult)), (Item-count/2, (Human, Body, Male, (Face, Towards), Agent-trait/Adult)), ((Item-count, High), Vehicle), (Item-count/1, Plant), (Item-count/1, Path))), (Background-view, (Paved-terrain, Road, Building, Outdoors, Plant, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Man-made-object/Navigational-object/Road,Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Urban))",
+    "coco_id": "357074",
+    "nsd_id": "31747"
+  },
+  "shared0427_nsd31783": {
+    "hed_short": "(Foreground-view, ((Item-count/2, ((Human, Human-agent), Body)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "357228",
+    "nsd_id": "31782"
+  },
+  "shared0428_nsd31802": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body)), (Item-count/2, Man-made-object/Toy))), (Background-view, (Uneven-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Uneven-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "95176",
+    "nsd_id": "31801"
+  },
+  "shared0429_nsd31838": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Entrance), (Item-count/3, Furnishing))), (Background-view, (Room, Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Entrance),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "95337",
+    "nsd_id": "31837"
+  },
+  "shared0430_nsd31937": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Furnishing)), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "357865",
+    "nsd_id": "31936"
+  },
+  "shared0431_nsd31965": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Desktop-computer), (Item-count/2, Keyboard), (Item-count/1, Laptop-computer), (Item-count/1, Furnishing))), (Background-view, (Room, Indoors, Man-made-object, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "95828",
+    "nsd_id": "31964"
+  },
+  "shared0432_nsd32054": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Animal), Composite-terrain)), (Background-view, (Outdoors, Building, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Composite-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant))",
+    "coco_id": "96161",
+    "nsd_id": "32053"
+  },
+  "shared0433_nsd32233": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Furnishing), (Item-count/1, Animal))), (Background-view, (Terrain/Sand, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sand,Property/Environmental-property/Outdoors))",
+    "coco_id": "359085",
+    "nsd_id": "32232"
+  },
+  "shared0434_nsd32304": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Animal), (Item-count/1, Plant))), (Background-view, (Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "97201",
+    "nsd_id": "32303"
+  },
+  "shared0435_nsd32308": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body, Agent-trait/Adult)), (Item-count/2, Laptop-computer), ((Item-count, High), Furnishing), ((Item-count, High), Pen), ((Item-count, High), Notebook))), (Background-view, (Indoors, Room, (Human, Body), Furnishing, Plant, Display-device))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Device/Assistive-device/Writing-device/Pen),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Document/Notebook))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Building/Room,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Furnishing,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Device/IO-device/Output-device/Display-device))",
+    "coco_id": "97218",
+    "nsd_id": "32307"
+  },
+  "shared0436_nsd32626": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/3, Man-made-object))), (Background-view, (Plant, Indoors, Room))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Building/Room))",
+    "coco_id": "98480",
+    "nsd_id": "32625"
+  },
+  "shared0437_nsd32644": {
+    "hed_short": "(Foreground-view, (Item-count/4, Animal)), (Background-view, (Grassy-terrain, Field, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors))",
+    "coco_id": "60117",
+    "nsd_id": "32643"
+  },
+  "shared0438_nsd32717": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Cellphone), ((Item-count, High), Plant))), (Background-view, (Rocky-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Computing-device/Cellphone),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Rocky-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "147547",
+    "nsd_id": "32716"
+  },
+  "shared0439_nsd32772": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), ((Item-count, High), Plant))), (Background-view, (Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "361193",
+    "nsd_id": "32771"
+  },
+  "shared0440_nsd32773": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/3, Furnishing))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "361197",
+    "nsd_id": "32772"
+  },
+  "shared0441_nsd32858": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Towards), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), (Item-count/2, Word), (Item-count/1, Character))), (Background-view, (Sloped-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "99363",
+    "nsd_id": "32857"
+  },
+  "shared0442_nsd32892": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Furnishing), (Item-count/1, Roof), (Item-count/1, River))), (Background-view, (Urban, Outdoors, Paved-terrain, Building, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Roof),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Urban,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Man-made-object/Building,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "361648",
+    "nsd_id": "32891"
+  },
+  "shared0443_nsd32911": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/3, Plant), (Item-count/4, Tool))), (Background-view, (Book, Room, Furnishing, Indoors, Plant, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Device/Tool))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Document/Book,Item/Object/Man-made-object/Building/Room,Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object))",
+    "coco_id": "99580",
+    "nsd_id": "32910"
+  },
+  "shared0444_nsd33132": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, Female, (Face, Towards), Agent-trait/Adult)), (Item-count/1, (Human, Body, Female, (Face, Away-from), Agent-trait/Adolescent)), (Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Older-adult)), ((Item-count, High), Furnishing))), (Background-view, (Indoors, Furnishing, Room, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adolescent)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Older-adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "100396",
+    "nsd_id": "33131"
+  },
+  "shared0445_nsd33172": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Grassy-terrain, Path, Outdoors,Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Man-made-object/Navigational-object/Path,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "362677",
+    "nsd_id": "33171"
+  },
+  "shared0446_nsd33190": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), (Item-count/2, (Human, Body, Female, (Face, Towards), Agent-trait/Child)), ((Item-count/1, (Animal, Animal-agent)), Walk), (Item-count/1, Vehicle))), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Child)),((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent)),Action/Move/Move-body-part/Move-lower-extremity/Walk),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "100599",
+    "nsd_id": "33189"
+  },
+  "shared0447_nsd33246": {
+    "hed_short": "(Foreground-view, (Item-count/1, Furnishing)), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "100863",
+    "nsd_id": "33245"
+  },
+  "shared0448_nsd33290": {
+    "hed_short": "(Foreground-view, (Item-count/1, Train)), (Background-view, (Outdoors, Rocky-terrain,Plant, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Rocky-terrain,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object))",
+    "coco_id": "101069",
+    "nsd_id": "33289"
+  },
+  "shared0449_nsd33522": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Laptop-computer), ((Item-count, High), Word), (Item-count/1, Computer-mouse), (Item-count/1, Furnishing), (Item-count/1, Ingestible-object), (Item-count/1, Notebook), (Item-count/1, Pen))), (Background-view, (Desktop-computer, Book, Drawing, Furnishing, Room, Indoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Document/Notebook),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device/Writing-device/Pen))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Device/Computing-device/Desktop-computer,Item/Object/Man-made-object/Document/Book,Item/Object/Man-made-object/Media/Visualization/Image/Drawing,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "101952",
+    "nsd_id": "33521"
+  },
+  "shared0450_nsd33544": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/2, Clock-face))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "570785",
+    "nsd_id": "33543"
+  },
+  "shared0451_nsd33753": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Furnishing), (Item-count/1, Display-device), (Item-count/3, Man-made-object))), (Background-view, (Room, Indoors, Painting, Book, Entrance, Photograph, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Output-device/Display-device),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Media/Visualization/Image/Painting,Item/Object/Man-made-object/Document/Book,Item/Object/Man-made-object/Building/Entrance,Item/Object/Man-made-object/Media/Visualization/Image/Photograph,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "365003",
+    "nsd_id": "33752"
+  },
+  "shared0452_nsd33814": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Away-from), Agent-trait/Adult)), ((Item-count, High), Ingestible-object))), (Background-view, (Outdoors, Urban, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "365218",
+    "nsd_id": "33813"
+  },
+  "shared0453_nsd33907": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Outdoors, Plant, Sloped-terrain, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Rural))",
+    "coco_id": "103366",
+    "nsd_id": "33906"
+  },
+  "shared0454_nsd34069": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body)), ((Item-count, High), Man-made-object/Toy))), (Background-view, (Aircraft, Building, Outdoors, Natural-feature/Sky, Rural, Mountain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Vehicle/Aircraft,Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Mountain))",
+    "coco_id": "366146",
+    "nsd_id": "34068"
+  },
+  "shared0455_nsd34081": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/1, Runway), (Item-count/3, (Human, Body, Agent-trait/Adult)), (Item-count/2, Word))), (Background-view, (Outdoors, Paved-terrain, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Runway),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "104044",
+    "nsd_id": "34080"
+  },
+  "shared0456_nsd34090": {
+    "hed_short": "(Foreground-view, (Item-count/3, Animal)), (Background-view, (Grassy-terrain, Plant, Outdoors, Rural, Animal))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Biological-item/Organism/Animal))",
+    "coco_id": "104081",
+    "nsd_id": "34089"
+  },
+  "shared0457_nsd34127": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Outdoors, Sloped-terrain, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Sloped-terrain,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "366396",
+    "nsd_id": "34126"
+  },
+  "shared0458_nsd34187": {
+    "hed_short": "(Foreground-view, (Item-count/3, Furnishing)), (Background-view, (Room, Plant, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Item/Biological-item/Organism/Plant,Property/Environmental-property/Indoors))",
+    "coco_id": "104502",
+    "nsd_id": "34186"
+  },
+  "shared0459_nsd34239": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Plant, Outdoors, Grassy-terrain, Field, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Rural))",
+    "coco_id": "366802",
+    "nsd_id": "34238"
+  },
+  "shared0460_nsd34419": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, Male, (Face, Towards), Agent-trait/Child)), (Item-count/3, Man-made-object/Toy))), (Background-view, (Outdoors, Building, (Human, Body), Man-made-object/Toy, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Toy,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "367552",
+    "nsd_id": "34418"
+  },
+  "shared0461_nsd34604": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "106107",
+    "nsd_id": "34603"
+  },
+  "shared0462_nsd34752": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body)), (Item-count/1, Animal))), (Background-view, (Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "368852",
+    "nsd_id": "34751"
+  },
+  "shared0463_nsd34830": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), (Item-count/1, Road))), (Background-view, (Paved-terrain, Outdoors, Plant, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building))",
+    "coco_id": "369171",
+    "nsd_id": "34829"
+  },
+  "shared0464_nsd34846": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/2, Animal), Grassy-terrain, Field)), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "369230",
+    "nsd_id": "34845"
+  },
+  "shared0465_nsd34851": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Plant), (Item-count/1, Path), Grassy-terrain)), (Background-view, ((Human, Body), Building, Clock-face, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),Property/Environmental-property/Terrain/Grassy-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "369253",
+    "nsd_id": "34850"
+  },
+  "shared0466_nsd34875": {
+    "hed_short": "(Foreground-view, (Item-count/1, (Human, Body, (Face, Away-from), Male, Agent-trait/Older-adult))), (Background-view, (Car, Outdoors, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Older-adult))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Vehicle/Car,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban))",
+    "coco_id": "107204",
+    "nsd_id": "34874"
+  },
+  "shared0467_nsd34976": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Agent-trait/Adult)), (Item-count/1, Man-made-object))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "17935",
+    "nsd_id": "34975"
+  },
+  "shared0468_nsd35095": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Grassy-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "542304",
+    "nsd_id": "35094"
+  },
+  "shared0469_nsd35130": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Animal), (Item-count/2, Plant))), (Background-view, (Outdoors, Rural, Grassy-terrain, Field, Sloped-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Terrain/Sloped-terrain))",
+    "coco_id": "370369",
+    "nsd_id": "35129"
+  },
+  "shared0470_nsd35744": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Animal), Dirt-terrain)), (Background-view, (Natural-feature/Sky, Plant, Outdoors, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Dirt-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building))",
+    "coco_id": "110611",
+    "nsd_id": "35743"
+  },
+  "shared0471_nsd35753": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Furnishing)), (Background-view, (Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "372775",
+    "nsd_id": "35752"
+  },
+  "shared0472_nsd35791": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adolescent)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "110780",
+    "nsd_id": "35790"
+  },
+  "shared0473_nsd35799": {
+    "hed_short": "(Foreground-view, (Item-count/3, Animal)), (Background-view, (Grassy-terrain, Field, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "372959",
+    "nsd_id": "35798"
+  },
+  "shared0474_nsd35987": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Entrance))), (Background-view, (Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Entrance))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "373679",
+    "nsd_id": "35986"
+  },
+  "shared0475_nsd36068": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, (Face, Away-from), Male, Agent-trait/Adult)), (Item-count/1, (Human, Body, (Face, Away-from), Male, Agent-trait/Child)), (Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Adolescent)), (Item-count/3, Man-made-object/Toy))), (Background-view, (Outdoors, Paved-terrain, Path, Building, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adolescent)),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Man-made-object/Navigational-object/Path,Item/Object/Man-made-object/Building,Property/Environmental-property/Urban))",
+    "coco_id": "373970",
+    "nsd_id": "36067"
+  },
+  "shared0476_nsd36259": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Path, Composite-terrain, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Path,Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "112734",
+    "nsd_id": "36258"
+  },
+  "shared0477_nsd36477": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), (Item-count/1, Boat))), (Background-view, (River, Natural-feature/Ocean, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Boat))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/River,Item/Object/Natural-object/Natural-feature/Ocean,Item/Biological-item/Organism/Plant))",
+    "coco_id": "113593",
+    "nsd_id": "36476"
+  },
+  "shared0478_nsd36570": {
+    "hed_short": "(Foreground-view, (Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Adult))), (Background-view, (Ingestible-object, Furnishing, Room, Indoors, Photograph, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Ingestible-object,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Media/Visualization/Image/Photograph,Item/Object/Man-made-object))",
+    "coco_id": "114035",
+    "nsd_id": "36569"
+  },
+  "shared0479_nsd36577": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/2, Clock-face), ((Item-count, High), Plant), (Item-count/1, River), Grassy-terrain)), (Background-view, (Outdoors, Urban, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River),Property/Environmental-property/Terrain/Grassy-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "114077",
+    "nsd_id": "36576"
+  },
+  "shared0480_nsd36624": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), (Item-count/1, Road))), (Background-view, (Sloped-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "376407",
+    "nsd_id": "36623"
+  },
+  "shared0481_nsd36630": {
+    "hed_short": "(Foreground-view, (Item-count/1, Furnishing)), (Background-view, (Path, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Path,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "114274",
+    "nsd_id": "36629"
+  },
+  "shared0482_nsd36683": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Car))), (Background-view, (Building, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors))",
+    "coco_id": "376643",
+    "nsd_id": "36682"
+  },
+  "shared0483_nsd36732": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Animal, Animal-agent)), Walk)), (Background-view, (Grassy-terrain, Field, Plant, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent)),Action/Move/Move-body-part/Move-lower-extremity/Walk)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "376858",
+    "nsd_id": "36731"
+  },
+  "shared0484_nsd36760": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, Agent-trait/Adult)), (Item-count/2, Man-made-object/Toy))), (Background-view, (Outdoors, Plant, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "114822",
+    "nsd_id": "36759"
+  },
+  "shared0485_nsd36911": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), Uneven-terrain, ((Item-count, High), Plant))), (Background-view, (Natural-feature/Sky, Rural, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Uneven-terrain,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural,Property/Environmental-property/Outdoors))",
+    "coco_id": "377576",
+    "nsd_id": "36910"
+  },
+  "shared0486_nsd36946": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Vehicle), (Item-count/2, Word), ((Item-count, High), Icon))), (Background-view, (Outdoors, Dirt-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Word),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Media/Visualization/Image/Icon))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Dirt-terrain))",
+    "coco_id": "377703",
+    "nsd_id": "36945"
+  },
+  "shared0487_nsd36975": {
+    "hed_short": "(Foreground-view, ((Item-count/1, River), ((Item-count, High), Plant))), (Background-view, (Plant, Path, Leaf-covered-terrain, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Navigational-object/Path,Property/Environmental-property/Terrain/Leaf-covered-terrain,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "115637",
+    "nsd_id": "36974"
+  },
+  "shared0488_nsd36979": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Ingestible-object), ((Item-count, High), Plant), (Item-count/2, Furnishing), (Item-count/1, Assistive-device))), (Background-view, (Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "115649",
+    "nsd_id": "36978"
+  },
+  "shared0489_nsd37060": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Road), (Item-count/1, Car), (Item-count/1, Plant), (Item-count/2, Man-made-object))), (Background-view, (Building, Car, Man-made-object, Plant, Outdoors, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Vehicle/Car,Item/Object/Man-made-object,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban))",
+    "coco_id": "115967",
+    "nsd_id": "37059"
+  },
+  "shared0490_nsd37222": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/1, Plant))), (Background-view, (Ingestible-object, Man-made-object, Room, Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Ingestible-object,Item/Object/Man-made-object,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "116588",
+    "nsd_id": "37221"
+  },
+  "shared0491_nsd37225": {
+    "hed_short": "(Foreground-view, (Item-count/2, Ingestible-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Ingestible-object))",
+    "coco_id": "116603",
+    "nsd_id": "37224"
+  },
+  "shared0492_nsd37437": {
+    "hed_short": "(Background-view, (Vehicle, Car, (Human, Body), Plant, Road, Urban, Natural-feature/Sky, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Vehicle,Item/Object/Man-made-object/Vehicle/Car,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Navigational-object/Road,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object))",
+    "coco_id": "150636",
+    "nsd_id": "37436"
+  },
+  "shared0493_nsd37495": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Towards))), (Play, (Item-count/1, Man-made-object/Toy))), ((Item-count/1, ((Human, Human-agent), Body, Female)), Play), (Item-count/1, Word))), (Background-view, (Grassy-terrain, Field, Outdoors, Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards))),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female)),Action/Perform/Play),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "379713",
+    "nsd_id": "37494"
+  },
+  "shared0494_nsd37609": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Agent-trait/Adult)), (Item-count/2, Man-made-object/Toy))), (Background-view, (Sloped-terrain, Plant, Outdoors, Rural, (Human, Body), Man-made-object/Toy))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Toy))",
+    "coco_id": "380227",
+    "nsd_id": "37608"
+  },
+  "shared0495_nsd37737": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Road), (Item-count/1, Building), ((Item-count, High), Plant))), (Background-view, (Building, Car, Outdoors, Natural-feature/Sky, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Vehicle/Car,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban))",
+    "coco_id": "380729",
+    "nsd_id": "37736"
+  },
+  "shared0496_nsd37802": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Animal)), (Background-view, (Grassy-terrain, Mountain, Outdoors, Natural-feature/Sky, Rural, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Mountain,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural,Item/Biological-item/Organism/Plant))",
+    "coco_id": "380989",
+    "nsd_id": "37801"
+  },
+  "shared0497_nsd37928": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, Agent-trait/Adult)), (Item-count/1, Man-made-object/Toy))), (Background-view, (Natural-feature/Ocean, Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "282032",
+    "nsd_id": "37927"
+  },
+  "shared0498_nsd38023": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Animal), (Item-count/1, River), ((Item-count, High), Plant), Grassy-terrain, Field)), (Background-view, (Building, Plant, Outdoors, Natural-feature/Sky, Animal))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Item/Biological-item/Organism/Animal))",
+    "coco_id": "119669",
+    "nsd_id": "38022"
+  },
+  "shared0499_nsd38026": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Away-from), Female, Agent-trait/Adult)), (Item-count/1, Man-made-object/Toy))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "575164",
+    "nsd_id": "38025"
+  },
+  "shared0500_nsd38061": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Animal), Composite-terrain)), (Background-view, (Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Composite-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "381961",
+    "nsd_id": "38060"
+  },
+  "shared0501_nsd38247": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), (Item-count/1, River))), (Background-view, (Plant, Outdoors, Rural, Dirt-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Property/Environmental-property/Terrain/Dirt-terrain))",
+    "coco_id": "353175",
+    "nsd_id": "38246"
+  },
+  "shared0502_nsd38279": {
+    "hed_short": "(Foreground-view, ((Item-count/2, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Outdoors, Sloped-terrain, Plant, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Sloped-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural))",
+    "coco_id": "120655",
+    "nsd_id": "38278"
+  },
+  "shared0503_nsd38298": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Vehicle), (Item-count/1, Road), ((Item-count, High), Photograph))), (Background-view, (Building, Plant, Outdoors, Urban, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Media/Visualization/Image/Photograph))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "382890",
+    "nsd_id": "38297"
+  },
+  "shared0504_nsd38311": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), ((Item-count, High), Plant))), (Background-view, (Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "382951",
+    "nsd_id": "38310"
+  },
+  "shared0505_nsd38359": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), Grassy-terrain, Field)), (Background-view, (Natural-feature/Sky, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "120987",
+    "nsd_id": "38358"
+  },
+  "shared0506_nsd38484": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Rocky-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Rocky-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "383641",
+    "nsd_id": "38483"
+  },
+  "shared0507_nsd38487": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing), (Item-count/1, Man-made-object))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "383652",
+    "nsd_id": "38486"
+  },
+  "shared0508_nsd38495": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), (Item-count/1, Ingestible-object))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Ingestible-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "413472",
+    "nsd_id": "38494"
+  },
+  "shared0509_nsd38642": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Laptop-computer), (Item-count/1, Desktop-computer), (Item-count/1, Keyboard), (Item-count/1, Computer-mouse), (Item-count/1, Furnishing))), (Background-view, (Room, Furnishing, Indoors, Notebook, Man-made-object, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Document/Notebook,Item/Object/Man-made-object,Item/Biological-item/Organism/Plant))",
+    "coco_id": "384235",
+    "nsd_id": "38641"
+  },
+  "shared0510_nsd38795": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean, Natural-feature/Sky, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object))",
+    "coco_id": "544738",
+    "nsd_id": "38794"
+  },
+  "shared0511_nsd38818": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), Rocky-terrain, (Item-count/1, Path))), (Background-view, (Plant, Outdoors, Natural-feature/Sky, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),Property/Environmental-property/Terrain/Rocky-terrain,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object/Building))",
+    "coco_id": "122776",
+    "nsd_id": "38817"
+  },
+  "shared0512_nsd38830": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Train), ((Item-count, High), Plant), (Item-count/1, Word), ((Item-count, High), Character))), (Background-view, (Outdoors, Rocky-terrain, Natural-feature/Sky, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Vehicle/Train),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Rocky-terrain,Item/Object/Natural-object/Natural-feature/Sky,Item/Biological-item/Organism/Plant))",
+    "coco_id": "122811",
+    "nsd_id": "38829"
+  },
+  "shared0513_nsd38854": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Vehicle), Rocky-terrain)), (Background-view, (Plant, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),Property/Environmental-property/Terrain/Rocky-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "282631",
+    "nsd_id": "38853"
+  },
+  "shared0514_nsd38979": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Man-made-object), ((Item-count, High), Furnishing))), (Background-view, (Room, Indoors, Photograph))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Media/Visualization/Image/Photograph))",
+    "coco_id": "282707",
+    "nsd_id": "38978"
+  },
+  "shared0515_nsd39048": {
+    "hed_short": "(Foreground-view, ((Item-count/2, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Dirt-terrain, Outdoors, (Human, Body), Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Dirt-terrain,Property/Environmental-property/Outdoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "123692",
+    "nsd_id": "39047"
+  },
+  "shared0516_nsd39059": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing)))",
+    "coco_id": "385864",
+    "nsd_id": "39058"
+  },
+  "shared0517_nsd39096": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), Grassy-terrain, Field)), (Background-view, (Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "123891",
+    "nsd_id": "39095"
+  },
+  "shared0518_nsd39290": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/2, Furnishing))), (Background-view, (Outdoors, Paved-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain))",
+    "coco_id": "124711",
+    "nsd_id": "39289"
+  },
+  "shared0519_nsd39299": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Boat), Natural-feature/Ocean)), (Background-view, (Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle/Boat),Item/Object/Natural-object/Natural-feature/Ocean)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "124747",
+    "nsd_id": "39298"
+  },
+  "shared0520_nsd39370": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Furnishing), (Item-count/1, Book), (Item-count/2, Word))), (Background-view, (Indoors, Furnishing, Room))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Document/Book),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room))",
+    "coco_id": "125042",
+    "nsd_id": "39369"
+  },
+  "shared0521_nsd39403": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/2, Furnishing))), (Background-view, (Ingestible-object, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Ingestible-object,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "387318",
+    "nsd_id": "39402"
+  },
+  "shared0522_nsd39510": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Animal), Grassy-terrain, Field)), (Background-view, (Plant, Animal, River, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Item/Biological-item/Organism/Animal,Item/Object/Natural-object/Natural-feature/River,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "125586",
+    "nsd_id": "39509"
+  },
+  "shared0523_nsd39548": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, (Human, Body, Agent-trait/Adult)))), (Background-view, (Composite-terrain, Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "125703",
+    "nsd_id": "39547"
+  },
+  "shared0524_nsd39554": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Animal), (Item-count/1, (Human, Body, Male, Agent-trait/Adult)), (Item-count/1, (Human, Body, Female, Agent-trait/Adult)), Dirt-terrain)), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),Property/Environmental-property/Terrain/Dirt-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "125725",
+    "nsd_id": "39553"
+  },
+  "shared0525_nsd39842": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Towards), Agent-trait/Adolescent)), (Action/Ride, (Item-count/1, (Animal, Animal-agent))), Walk)), (Background-view, (Composite-terrain, Building, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adolescent)),(Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent))),Action/Move/Move-body-part/Move-lower-extremity/Walk)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant))",
+    "coco_id": "388980",
+    "nsd_id": "39841"
+  },
+  "shared0526_nsd39998": {
+    "hed_short": "(Foreground-view, (((Item-count/2, (Animal, Animal-agent)), Action), Composite-terrain, Field)), (Background-view, (Outdoors, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Animal,Agent/Animal-agent)),Action),Property/Environmental-property/Terrain/Composite-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "389582",
+    "nsd_id": "39997"
+  },
+  "shared0527_nsd40154": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Outdoors, Uneven-terrain, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Uneven-terrain,Property/Environmental-property/Rural))",
+    "coco_id": "390120",
+    "nsd_id": "40153"
+  },
+  "shared0528_nsd40236": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Adult)), (Item-count/1, Man-made-object))), (Background-view, (Dirt-terrain, Outdoors, Natural-feature/Sky, Bicycle, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Dirt-terrain,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object/Vehicle/Bicycle,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "239828",
+    "nsd_id": "40235"
+  },
+  "shared0529_nsd40424": {
+    "hed_short": "(Foreground-view, ((((Item-count, High), ((Human, Human-agent), Body)), (Play, ((Item-count, High), Man-made-object/Toy))), (Item-count/1, Machine))), (Background-view, (Plant, Sloped-terrain, Outdoors, Rural, Natural-feature/Sky, Machine))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body)),(Action/Perform/Play,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Machine))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object/Device/Machine))",
+    "coco_id": "129060",
+    "nsd_id": "40423"
+  },
+  "shared0530_nsd40549": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, (Face, Towards), Male, Agent-trait/Child)), (Item-count/2, Assistive-device), (Item-count/2, Word))), (Background-view, (Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Assistive-device),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "391678",
+    "nsd_id": "40548"
+  },
+  "shared0531_nsd40576": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, Female, (Face, Towards), Agent-trait/Adult)), (Item-count/2, Man-made-object/Toy))), (Background-view, (Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "391754",
+    "nsd_id": "40575"
+  },
+  "shared0532_nsd40722": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Animal), Grassy-terrain, (Item-count/1, Plant))), (Background-view, (Outdoors, Rural, Natural-feature/Sky, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky,Item/Biological-item/Organism/Plant))",
+    "coco_id": "130181",
+    "nsd_id": "40721"
+  },
+  "shared0533_nsd40771": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), Grassy-terrain, Field)), (Background-view, (Plant, Outdoors, Hill, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Hill,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "392556",
+    "nsd_id": "40770"
+  },
+  "shared0534_nsd40841": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), (Item-count/1, Plant))), (Background-view, (Grassy-terrain, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "130681",
+    "nsd_id": "40840"
+  },
+  "shared0535_nsd40847": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Building, Urban, Road, Natural-feature/Sky, Vehicle))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Urban,Item/Object/Man-made-object/Navigational-object/Road,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object/Vehicle))",
+    "coco_id": "392851",
+    "nsd_id": "40846"
+  },
+  "shared0536_nsd40910": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Grassy-terrain, Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "196584",
+    "nsd_id": "40909"
+  },
+  "shared0537_nsd40921": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object)), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "371353",
+    "nsd_id": "40920"
+  },
+  "shared0538_nsd40925": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/1, Word), (Item-count/1, Runway))), (Background-view, (Outdoors, Truck, Natural-feature/Sky, Aircraft))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Runway))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Vehicle/Truck,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object/Vehicle/Aircraft))",
+    "coco_id": "130973",
+    "nsd_id": "40924"
+  },
+  "shared0539_nsd40936": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Laptop-computer), (Item-count/1, Computer-mouse), (Item-count/1, Furnishing), ((Item-count, High), Furnishing))), (Background-view, (Room, Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "131011",
+    "nsd_id": "40935"
+  },
+  "shared0540_nsd40980": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), Sloped-terrain)), (Background-view,  (Mountain, Rural, Natural-feature/Sky, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),Property/Environmental-property/Terrain/Sloped-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Mountain,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "21826",
+    "nsd_id": "40979"
+  },
+  "shared0541_nsd41057": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/1, Clock-face))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "131524",
+    "nsd_id": "41056"
+  },
+  "shared0542_nsd41098": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Plant))), (Background-view, (Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "284089",
+    "nsd_id": "41097"
+  },
+  "shared0543_nsd41117": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Adult)), (Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Infant)), (Item-count/1, Laptop-computer))), (Background-view, (Indoors, Furnishing, Room))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Infant)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room))",
+    "coco_id": "131763",
+    "nsd_id": "41116"
+  },
+  "shared0544_nsd41138": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/1, Clock-face), (Item-count/3, Sculpture))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Media/Visualization/Sculpture))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "394008",
+    "nsd_id": "41137"
+  },
+  "shared0545_nsd41163": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Boat), (Item-count/1, River))), (Background-view, (Mountain, Plant, Outdoors, Building, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Boat),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Mountain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "131967",
+    "nsd_id": "41162"
+  },
+  "shared0546_nsd41483": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Plant), ((Item-count, High), Furnishing))), (Background-view, (Furnishing, Room, Indoors, Plant, Photograph))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Biological-item/Organism/Plant),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Media/Visualization/Image/Photograph))",
+    "coco_id": "133281",
+    "nsd_id": "41482"
+  },
+  "shared0547_nsd41567": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Furnishing), (Item-count/1, Display-device), (Item-count/1, Drawing))), (Background-view, (Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Output-device/Display-device),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Image/Drawing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "395758",
+    "nsd_id": "41566"
+  },
+  "shared0548_nsd41575": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Furnishing), (Item-count/1, Desktop-computer), (Item-count/1, Entrance))), (Background-view, (Room, Furnishing, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Entrance))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors))",
+    "coco_id": "395775",
+    "nsd_id": "41574"
+  },
+  "shared0549_nsd41624": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Cellphone), (Item-count/1, Tool))), (Background-view, (Furnishing, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Computing-device/Cellphone),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Tool))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors))",
+    "coco_id": "197068",
+    "nsd_id": "41623"
+  },
+  "shared0550_nsd41654": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/1, Runway), (Item-count/1, Word), ((Item-count, High), Truck))), (Background-view, (Outdoors, Paved-terrain, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Runway),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle/Truck))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "66014",
+    "nsd_id": "41653"
+  },
+  "shared0551_nsd41711": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Away-from), Male, Agent-trait/Adult)), (Item-count/1, (Human, Body, (Face, Away-from), Female, Agent-trait/Adolescent)), (Item-count/1, Furnishing), (Item-count/2, Word))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adolescent)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "134169",
+    "nsd_id": "41710"
+  },
+  "shared0552_nsd41779": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Animal), Grassy-terrain, Sloped-terrain)), (Background-view, (Plant, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Terrain/Sloped-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "396550",
+    "nsd_id": "41778"
+  },
+  "shared0553_nsd41815": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Animal)), (Background-view, (Building, Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "134562",
+    "nsd_id": "41814"
+  },
+  "shared0554_nsd41928": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Furnishing))), (Background-view, (Plant, Outdoors, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building))",
+    "coco_id": "135032",
+    "nsd_id": "41927"
+  },
+  "shared0555_nsd41935": {
+    "hed_short": "(Foreground-view, (Item-count/1, Furnishing)), (Background-view, (Building, Urban, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Urban,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "397192",
+    "nsd_id": "41934"
+  },
+  "shared0556_nsd42008": {
+    "hed_short": "(Foreground-view, (Item-count/1, Aircraft)), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "135316",
+    "nsd_id": "42007"
+  },
+  "shared0557_nsd42127": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/2, Furnishing))), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "22627",
+    "nsd_id": "42126"
+  },
+  "shared0558_nsd42167": {
+    "hed_short": "(Foreground-view, (((Item-count/2, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy))), (Item-count/2, Character), Composite-terrain)), (Background-view, (Field, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/2,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Character),Property/Environmental-property/Terrain/Composite-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "398083",
+    "nsd_id": "42166"
+  },
+  "shared0559_nsd42172": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, Agent-trait/Child)), ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))))), (Background-view, (Grassy-terrain, Field, Plant, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Child)),((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "135965",
+    "nsd_id": "42171"
+  },
+  "shared0560_nsd42215": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/2, Ingestible-object))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Ingestible-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "136111",
+    "nsd_id": "42214"
+  },
+  "shared0561_nsd42225": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing), ((Item-count, High), Assistive-device), ((Item-count, High), Plant), (Item-count/1, Furnishing))), (Background-view, (Indoors, Man-made-object, Photograph, Furnishing, Room))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Device/Assistive-device),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object,Item/Object/Man-made-object/Media/Visualization/Image/Photograph,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room))",
+    "coco_id": "136142",
+    "nsd_id": "42224"
+  },
+  "shared0562_nsd42239": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), ((Item-count, High), Ingestible-object), (Item-count/3, Assistive-device), ((Item-count, High), Furnishing))), (Background-view, (Plant, Urban, (Human, Body), Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Device/Assistive-device),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Urban,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "22696",
+    "nsd_id": "42238"
+  },
+  "shared0563_nsd42300": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Animal), Grassy-terrain, ((Item-count, High), Plant))), (Background-view, (Outdoors, Hill, Rural, Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Hill,Property/Environmental-property/Rural,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "398540",
+    "nsd_id": "42299"
+  },
+  "shared0564_nsd42474": {
+    "hed_short": "(Foreground-view, (Item-count/2, Furnishing)), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "399162",
+    "nsd_id": "42473"
+  },
+  "shared0565_nsd42564": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), (Item-count/1, Word), Rocky-terrain)), (Background-view, (Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),Property/Environmental-property/Terrain/Rocky-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "197656",
+    "nsd_id": "42563"
+  },
+  "shared0566_nsd42643": {
+    "hed_short": "(Foreground-view, (Item-count/3, Animal)), (Background-view, (Composite-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "399835",
+    "nsd_id": "42642"
+  },
+  "shared0567_nsd42649": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Grassy-terrain, Field, Outdoors, Plant, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "137706",
+    "nsd_id": "42648"
+  },
+  "shared0568_nsd42698": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Composite-terrain, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "399984",
+    "nsd_id": "42697"
+  },
+  "shared0569_nsd42782": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Furnishing), ((Item-count, High), Plant), (Item-count/1, Drawing))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Image/Drawing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "138153",
+    "nsd_id": "42781"
+  },
+  "shared0570_nsd42852": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/3, Plant), (Item-count/1, Man-made-object), (Item-count/1, Word))), (Background-view, (Building, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors))",
+    "coco_id": "400581",
+    "nsd_id": "42851"
+  },
+  "shared0571_nsd42913": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), ((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing), (Item-count/4, Assistive-device))), (Background-view, (Outdoors, Building, Entrance, Paved-terrain, Urban, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Device/Assistive-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Building/Entrance,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Urban,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "229233",
+    "nsd_id": "42912"
+  },
+  "shared0572_nsd42947": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/1, Plant), (Item-count/1, Man-made-object/Toy), (Item-count/4, Photograph))), (Background-view, (Book, Furnishing, Painting, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Media/Visualization/Image/Photograph))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Document/Book,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Media/Visualization/Image/Painting,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "138785",
+    "nsd_id": "42946"
+  },
+  "shared0573_nsd42981": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Furnishing), (Item-count/1, Entrance))), (Background-view, (Room, Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Entrance))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "138904",
+    "nsd_id": "42980"
+  },
+  "shared0574_nsd43108": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), ((Item-count, High), Plant))), (Background-view, (Animal, Car, Plant, Grassy-terrain, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Animal,Item/Object/Man-made-object/Vehicle/Car,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "139344",
+    "nsd_id": "43107"
+  },
+  "shared0575_nsd43157": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Towards), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), (Item-count/4, Character))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "139551",
+    "nsd_id": "43156"
+  },
+  "shared0576_nsd43158": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Mountain), Grassy-terrain)), (Background-view, (Mountain, Outdoors, Natural-feature/Sky, Plant, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/Mountain),Property/Environmental-property/Terrain/Grassy-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Mountain,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural))",
+    "coco_id": "401699",
+    "nsd_id": "43157"
+  },
+  "shared0577_nsd43160": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Animal, Animal-agent)), Walk)), (Background-view, (Grassy-terrain, Field, Mountain, Outdoors, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent)),Action/Move/Move-body-part/Move-lower-extremity/Walk)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Object/Natural-object/Natural-feature/Mountain,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "139561",
+    "nsd_id": "43159"
+  },
+  "shared0578_nsd43165": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Away-from), Agent-trait/Adult)), (Item-count/1, Animal))), (Background-view, (Grassy-terrain, Field, Outdoors, Plant, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural))",
+    "coco_id": "401720",
+    "nsd_id": "43164"
+  },
+  "shared0579_nsd43225": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, Agent-trait/Adult)), (Item-count/1, Man-made-object), (Item-count/1, Furnishing), (Item-count/1, Path))), (Background-view, (Plant, Outdoors, River))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/River))",
+    "coco_id": "139815",
+    "nsd_id": "43224"
+  },
+  "shared0580_nsd43251": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object)), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "402057",
+    "nsd_id": "43250"
+  },
+  "shared0581_nsd43289": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Assistive-device), (Item-count/1, Pen), (Item-count/1, Word))), (Background-view, (Assistive-device))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device/Writing-device/Pen),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Device/Assistive-device))",
+    "coco_id": "402199",
+    "nsd_id": "43288"
+  },
+  "shared0582_nsd43429": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Grassy-terrain, Field, Sloped-terrain, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "140590",
+    "nsd_id": "43428"
+  },
+  "shared0583_nsd43430": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Ingestible-object), (Item-count/1, (Human, Body))))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body))))",
+    "coco_id": "198195",
+    "nsd_id": "43429"
+  },
+  "shared0584_nsd43446": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Male), Agent-trait/Child), (Item-count/1, Man-made-object/Toy))), (Background-view, (Grassy-terrain, Field, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male),Property/Agent-property/Agent-trait/Child),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors))",
+    "coco_id": "285588",
+    "nsd_id": "43445"
+  },
+  "shared0585_nsd43466": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), (Item-count/1, Animal))), (Background-view, (Rocky-terrain, Plant, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Rocky-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "140724",
+    "nsd_id": "43465"
+  },
+  "shared0586_nsd43501": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Grassy-terrain, Hill, Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Hill,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "154556",
+    "nsd_id": "43500"
+  },
+  "shared0587_nsd43620": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Animal, Animal-agent)), (Collide-with, (Item-count/1, (Animal, Animal-agent))))), (Background-view, (Grassy-terrain, Field, Outdoors, Plant, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent)),(Action/Perform/Collide-with,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent))))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "403535",
+    "nsd_id": "43619"
+  },
+  "shared0588_nsd43676": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Grassy-terrain, Outdoors, Rural, Mountain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Mountain))",
+    "coco_id": "403739",
+    "nsd_id": "43675"
+  },
+  "shared0589_nsd43690": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Towards), Agent-trait/Adult)), (Action/Ride, (Item-count/1, (Animal, Animal-agent))), Walk)), (Background-view, (Composite-terrain, Outdoors, Plant, Hill, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent))),Action/Move/Move-body-part/Move-lower-extremity/Walk)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Hill,Item/Object/Man-made-object/Building))",
+    "coco_id": "403789",
+    "nsd_id": "43689"
+  },
+  "shared0590_nsd43747": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), ((Item-count, High), Plant))), (Background-view, (Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "404007",
+    "nsd_id": "43746"
+  },
+  "shared0591_nsd43819": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Plant), (Item-count/1, Man-made-object/Toy))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "404282",
+    "nsd_id": "43818"
+  },
+  "shared0592_nsd43821": {
+    "hed_short": "(Foreground-view, (Item-count/3, Animal)), (Background-view, (Grassy-terrain, Field, Outdoors, Plant, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "504289",
+    "nsd_id": "43820"
+  },
+  "shared0593_nsd43853": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Vehicle), ((Item-count, High), (Human, Body, Agent-trait/Adult)), (Item-count/1, Road))), (Background-view, (Outdoors, Rural, Natural-feature/Sky, Mountain, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Natural-object/Natural-feature/Mountain,Item/Biological-item/Organism/Plant))",
+    "coco_id": "196777",
+    "nsd_id": "43852"
+  },
+  "shared0594_nsd43951": {
+    "hed_short": "(Foreground-view, ((Item-count/2, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Walk, (Item-count/1, Runway)))), (Background-view, (Aircraft, Paved-terrain, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Move/Move-body-part/Move-lower-extremity/Walk,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Runway)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Vehicle/Aircraft,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "404823",
+    "nsd_id": "43950"
+  },
+  "shared0595_nsd43985": {
+    "hed_short": "(Foreground-view, (((Item-count/2, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), ((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), (Item-count/1, Word), (Item-count/1, Character))), (Background-view, (Outdoors, Composite-terrain, Field))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/2,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Composite-terrain,Item/Object/Natural-object/Natural-feature/Field))",
+    "coco_id": "142803",
+    "nsd_id": "43984"
+  },
+  "shared0596_nsd44053": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "405215",
+    "nsd_id": "44052"
+  },
+  "shared0597_nsd44098": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (River, Outdoors, Dirt-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/River,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Dirt-terrain))",
+    "coco_id": "143245",
+    "nsd_id": "44097"
+  },
+  "shared0598_nsd44108": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Older-adult)), (Reach, (Item-count/1, (Animal, Animal-agent))), Bite)), (Background-view, (Indoors, Furnishing, Room, Ingestible-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Older-adult)),(Action/Move/Move-body-part/Move-upper-extremity/Reach,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent))),Action/Move/Move-body-part/Move-face/Bite)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Item/Object/Ingestible-object))",
+    "coco_id": "405437",
+    "nsd_id": "44107"
+  },
+  "shared0599_nsd44139": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing))), (Background-view, (Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "388853",
+    "nsd_id": "44138"
+  },
+  "shared0600_nsd44145": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Man-made-object))), (Background-view, (Paved-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "143420",
+    "nsd_id": "44144"
+  },
+  "shared0601_nsd44185": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Boat), (Item-count/2, Animal))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Boat),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "143594",
+    "nsd_id": "44184"
+  },
+  "shared0602_nsd44325": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Animal), ((Item-count, High), (Human, Body, Agent-trait/Adult)))), (Background-view, (Dirt-terrain, Outdoors, Mountain, Vehicle, Building, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Dirt-terrain,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Mountain,Item/Object/Man-made-object/Vehicle,Item/Object/Man-made-object/Building,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "406292",
+    "nsd_id": "44324"
+  },
+  "shared0603_nsd44340": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), ((Item-count, High), Plant))), (Background-view, (Building, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "144193",
+    "nsd_id": "44339"
+  },
+  "shared0604_nsd44370": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors, Sloped-terrain, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Rural))",
+    "coco_id": "406445",
+    "nsd_id": "44369"
+  },
+  "shared0605_nsd44413": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Car), (Item-count/1, Road))), (Background-view, (Composite-terrain, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "406595",
+    "nsd_id": "44412"
+  },
+  "shared0606_nsd44706": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), (Item-count/1, Path))), (Background-view, (Outdoors, (Human, Body, Agent-trait/Adult), Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "407778",
+    "nsd_id": "44705"
+  },
+  "shared0607_nsd44721": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Away-from), Agent-trait/Adult)), (Item-count/1, Furnishing), (Item-count/1, Cellphone))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Cellphone))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "461187",
+    "nsd_id": "44720"
+  },
+  "shared0608_nsd44730": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Grassy-terrain, Field, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "24287",
+    "nsd_id": "44729"
+  },
+  "shared0609_nsd44737": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Towards), Agent-trait/Older-adult)), (Item-count/1, Furnishing))), (Background-view, (Outdoors, Paved-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Older-adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain))",
+    "coco_id": "504888",
+    "nsd_id": "44736"
+  },
+  "shared0610_nsd44845": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Furnishing))), (Background-view, ((Human, Body), Outdoors, Paved-terrain, Roof))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Man-made-object/Building/Roof))",
+    "coco_id": "146256",
+    "nsd_id": "44844"
+  },
+  "shared0611_nsd44972": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Vehicle), (Item-count/1, Building))), (Background-view, (Natural-feature/Sky, Paved-terrain, Cone, Outdoors, Icon))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Geometric-object/3D-shape/Cone,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Media/Visualization/Image/Icon))",
+    "coco_id": "408922",
+    "nsd_id": "44971"
+  },
+  "shared0612_nsd44981": {
+    "hed_short": "(Foreground-view, (Item-count/1, Aircraft)), (Background-view, (Outdoors, Natural-feature/Sky, Urban, Building, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant))",
+    "coco_id": "408965",
+    "nsd_id": "44980"
+  },
+  "shared0613_nsd45130": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Away-from), Agent-trait/Adult)), (Item-count/3, Furnishing), (Item-count/3, Plant), (Item-count/1, Bicycle))), (Background-view, (Vehicle, Paved-terrain, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Bicycle))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Vehicle,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Urban))",
+    "coco_id": "147331",
+    "nsd_id": "45129"
+  },
+  "shared0614_nsd45214": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Away-from), Male, Agent-trait/Adult)), (Item-count/1, (Human, Body, (Face, Away-from), Female, Agent-trait/Adult)), (Item-count/1, Box), (Item-count/1, Character))), (Background-view, (Paved-terrain, Building, Outdoors, Drawing, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Geometric-object/3D-shape/Box),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Media/Visualization/Image/Drawing,Property/Environmental-property/Urban))",
+    "coco_id": "147694",
+    "nsd_id": "45213"
+  },
+  "shared0615_nsd45357": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Building, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors))",
+    "coco_id": "148263",
+    "nsd_id": "45356"
+  },
+  "shared0616_nsd45596": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Ingestible-object), ((Item-count, High), Furnishing))), (Background-view, (Furnishing, (Human, Body, Agent-trait/Adult), Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "149221",
+    "nsd_id": "45595"
+  },
+  "shared0617_nsd45633": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, River))), (Background-view, (Rocky-terrain, Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Rocky-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "411475",
+    "nsd_id": "45632"
+  },
+  "shared0618_nsd45747": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Furnishing)), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "149791",
+    "nsd_id": "45746"
+  },
+  "shared0619_nsd45751": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean, Mountain, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Mountain,Item/Object/Man-made-object))",
+    "coco_id": "149810",
+    "nsd_id": "45750"
+  },
+  "shared0620_nsd45838": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Towards), Agent-trait/Adolescent)), (Item-count/1, (Human, Body, Male, Agent-trait/Adolescent)), (Item-count/3, Man-made-object/Toy))), (Background-view, (Composite-terrain, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adolescent)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adolescent)),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "153394",
+    "nsd_id": "45837"
+  },
+  "shared0621_nsd45844": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Vehicle), (Item-count/1, Road), (Item-count/1, Path), (Item-count/2, Character))), (Background-view, (Building, Composite-terrain, Plant, Outdoors, Urban, Natural-feature/Sky, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Terrain/Composite-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object))",
+    "coco_id": "150196",
+    "nsd_id": "45843"
+  },
+  "shared0622_nsd45946": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, (Face, Away-from), Male, Agent-trait/Adult)), (Action/Ride, (Item-count/1, Bicycle))), (Item-count/1, Road))), (Background-view, (Vehicle, Building, Urban, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Bicycle))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Vehicle,Item/Object/Man-made-object/Building,Property/Environmental-property/Urban,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "150559",
+    "nsd_id": "45945"
+  },
+  "shared0623_nsd45982": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Road), (Item-count/1, 2D-shape), (Item-count/3, Man-made-object))), (Background-view, (Outdoors, Paved-terrain, Plant, Urban, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Geometric-object/2D-shape),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "412855",
+    "nsd_id": "45981"
+  },
+  "shared0624_nsd45983": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Animal), (Item-count/1, Waterfall))), (Background-view, (Composite-terrain, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/Waterfall))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "412857",
+    "nsd_id": "45982"
+  },
+  "shared0625_nsd46000": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Plant, Outdoors, Grassy-terrain, Field, Sloped-terrain, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Rural))",
+    "coco_id": "369367",
+    "nsd_id": "45999"
+  },
+  "shared0626_nsd46003": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Animal), (Item-count/1, Path))), (Background-view, (Composite-terrain, Plant, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "412922",
+    "nsd_id": "46002"
+  },
+  "shared0627_nsd46037": {
+    "hed_short": "(Foreground-view, ((Item-count/2, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "150931",
+    "nsd_id": "46036"
+  },
+  "shared0628_nsd46102": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body)), (Item-count/1, Furnishing), Paved-terrain)), (Background-view, (Hill, River, Building, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),Property/Environmental-property/Terrain/Paved-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Hill,Item/Object/Natural-object/Natural-feature/River,Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "151163",
+    "nsd_id": "46101"
+  },
+  "shared0629_nsd46137": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/1, Clock-face))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "151307",
+    "nsd_id": "46136"
+  },
+  "shared0630_nsd46151": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Away-from), Male, Agent-trait/Adult)), (Item-count/1, Word))), (Background-view, (Man-made-object/Toy, Paved-terrain, Outdoors, (Human, Body), Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Toy,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "462134",
+    "nsd_id": "46150"
+  },
+  "shared0631_nsd46161": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Furnishing), (Item-count/1, Animal))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "151414",
+    "nsd_id": "46160"
+  },
+  "shared0632_nsd46275": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Path))), (Background-view, (Composite-terrain, Outdoors, Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "68996",
+    "nsd_id": "46274"
+  },
+  "shared0633_nsd46322": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (River, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/River,Property/Environmental-property/Outdoors))",
+    "coco_id": "414176",
+    "nsd_id": "46321"
+  },
+  "shared0634_nsd46373": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Cellphone), (Item-count/1, Furnishing)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Device/Computing-device/Cellphone),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing)))",
+    "coco_id": "152273",
+    "nsd_id": "46372"
+  },
+  "shared0635_nsd46381": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Towards), Agent-trait/Adult)), (Action/Ride, (Item-count/1, Bicycle))), (Item-count/1, Path))), (Background-view, (River, Plant, Paved-terrain, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Bicycle))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/River,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "152328",
+    "nsd_id": "46380"
+  },
+  "shared0636_nsd46461": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/2, Tool), (Item-count/1, Computer-mouse))), (Background-view, (Room, Indoors, Desktop-computer, Photograph, Clothing, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Tool),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer,Item/Object/Man-made-object/Media/Visualization/Image/Photograph,Item/Object/Man-made-object/Clothing,Item/Object/Man-made-object))",
+    "coco_id": "549729",
+    "nsd_id": "46460"
+  },
+  "shared0637_nsd46463": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "506039",
+    "nsd_id": "46462"
+  },
+  "shared0638_nsd46481": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Grassy-terrain, Field, Outdoors, Plant, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural))",
+    "coco_id": "414853",
+    "nsd_id": "46480"
+  },
+  "shared0639_nsd46524": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Outdoors, Paved-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain))",
+    "coco_id": "415026",
+    "nsd_id": "46523"
+  },
+  "shared0640_nsd46643": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/3, Furnishing))), (Background-view, (Furnishing, Indoors, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors,Item/Object/Man-made-object))",
+    "coco_id": "162230",
+    "nsd_id": "46642"
+  },
+  "shared0641_nsd46662": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Boat), Terrain/Sand)), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle/Boat),Property/Environmental-property/Terrain/Sand)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "415608",
+    "nsd_id": "46661"
+  },
+  "shared0642_nsd46807": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), (Item-count/1, River))), (Background-view, (Rocky-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Rocky-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "154011",
+    "nsd_id": "46806"
+  },
+  "shared0643_nsd46836": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Boat), Natural-feature/Ocean)), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Vehicle/Boat),Item/Object/Natural-object/Natural-feature/Ocean)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "416279",
+    "nsd_id": "46835"
+  },
+  "shared0644_nsd46862": {
+    "hed_short": "(Foreground-view, (Item-count/2, Furnishing)), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "154207",
+    "nsd_id": "46861"
+  },
+  "shared0645_nsd47034": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/2, Clock-face))), (Background-view, (Natural-feature/Sky, Outdoors, Hill, Rocky-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Hill,Property/Environmental-property/Terrain/Rocky-terrain))",
+    "coco_id": "416972",
+    "nsd_id": "47033"
+  },
+  "shared0646_nsd47071": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object)), (Background-view, (Furnishing, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors))",
+    "coco_id": "417141",
+    "nsd_id": "47070"
+  },
+  "shared0647_nsd47100": {
+    "hed_short": "(Foreground-view, ((Item-count/4, (Human, Body, Agent-trait/Adult)), ((Item-count, High), Man-made-object/Toy))), (Background-view, (Sloped-terrain, Natural-feature/Sky, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "417264",
+    "nsd_id": "47099"
+  },
+  "shared0648_nsd47201": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "417700",
+    "nsd_id": "47200"
+  },
+  "shared0649_nsd47291": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), ((Item-count, High), Plant))), (Background-view, (Book, Photograph, Display-device, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Document/Book,Item/Object/Man-made-object/Media/Visualization/Image/Photograph,Item/Object/Man-made-object/Device/IO-device/Output-device/Display-device,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "418115",
+    "nsd_id": "47290"
+  },
+  "shared0650_nsd47294": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "419212",
+    "nsd_id": "47293"
+  },
+  "shared0651_nsd47322": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Adult)), (Item-count/1, Man-made-object))), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "156084",
+    "nsd_id": "47321"
+  },
+  "shared0652_nsd47409": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body, (Face, Towards), Agent-trait/Adult)), ((Item-count, High), Man-made-object))), (Background-view, (Natural-feature/Ocean, Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "113449",
+    "nsd_id": "47408"
+  },
+  "shared0653_nsd47599": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "157119",
+    "nsd_id": "47598"
+  },
+  "shared0654_nsd47601": {
+    "hed_short": "(Foreground-view, ((Item-count/4, (Human, Body, Male, Agent-trait/Adolescent)), (Item-count/3, Cellphone), (Item-count/1, Path))), (Background-view, (River, Outdoors, Plant, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adolescent)),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Device/Computing-device/Cellphone),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/River,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "157125",
+    "nsd_id": "47600"
+  },
+  "shared0655_nsd47615": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/1, Entrance), (Item-count/1, Furnishing))), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Entrance),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "157181",
+    "nsd_id": "47614"
+  },
+  "shared0656_nsd47657": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing))), (Background-view, (Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "157342",
+    "nsd_id": "47656"
+  },
+  "shared0657_nsd47688": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing), (Item-count/1, Word))), (Background-view, (Indoors, (Human, Body, Agent-trait/Adult), Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "419586",
+    "nsd_id": "47687"
+  },
+  "shared0658_nsd48158": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Furnishing), (Item-count/1, Entrance))), (Background-view, (Room, Indoors, Furnishing, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Entrance))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Biological-item/Organism/Plant))",
+    "coco_id": "563961",
+    "nsd_id": "48157"
+  },
+  "shared0659_nsd48261": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/1, Clock-face), (Item-count/3, Sculpture))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Media/Visualization/Sculpture))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "159680",
+    "nsd_id": "48260"
+  },
+  "shared0660_nsd48375": {
+    "hed_short": "(Foreground-view, (Item-count/1, Clock-face)), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "422268",
+    "nsd_id": "48374"
+  },
+  "shared0661_nsd48380": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Tool), ((Item-count, High), Man-made-object/Toy), ((Item-count, High), Furnishing), (Item-count/1, Book), (Item-count/1, Display-device))), (Background-view, (Man-made-object, Room, Indoors, Furnishing, Man-made-object/Toy))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Tool),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Document/Book),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Output-device/Display-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Toy))",
+    "coco_id": "160142",
+    "nsd_id": "48379"
+  },
+  "shared0662_nsd48394": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Child)), (Item-count/2, Ingestible-object), (Item-count/1, Furnishing))), (Background-view, (Ingestible-object, Furnishing, Room, Indoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Ingestible-object,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "160181",
+    "nsd_id": "48393"
+  },
+  "shared0663_nsd48423": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), ((Item-count, High), Drawing), (Item-count/1, Man-made-object))), (Background-view, (River, Plant, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Media/Visualization/Image/Drawing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/River,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "463620",
+    "nsd_id": "48422"
+  },
+  "shared0664_nsd48509": {
+    "hed_short": "(Foreground-view, (Item-count/3, Animal)), (Background-view, (Dirt-terrain, Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Dirt-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "551063",
+    "nsd_id": "48508"
+  },
+  "shared0665_nsd48531": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Sloped-terrain, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "160735",
+    "nsd_id": "48530"
+  },
+  "shared0666_nsd48618": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/1, Runway))), (Background-view, (Plant, Outdoors, Paved-terrain, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Runway))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "161062",
+    "nsd_id": "48617"
+  },
+  "shared0667_nsd48619": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Aircraft), ((Item-count, High), Vehicle), (Item-count/1, Runway), ((Item-count, High), Character))), (Background-view, (Outdoors, Natural-feature/Sky, Paved-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle/Aircraft),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Runway),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Terrain/Paved-terrain))",
+    "coco_id": "423209",
+    "nsd_id": "48618"
+  },
+  "shared0668_nsd48623": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Pen), ((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing))), (Background-view, (Room, Furnishing, Indoors, Pen, Ingestible-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device/Writing-device/Pen),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Device/Assistive-device/Writing-device/Pen,Item/Object/Ingestible-object))",
+    "coco_id": "423222",
+    "nsd_id": "48622"
+  },
+  "shared0669_nsd48680": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Towards), Agent-trait/Adolescent)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "161328",
+    "nsd_id": "48679"
+  },
+  "shared0670_nsd48682": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Furnishing), (Item-count/2, Cellphone), (Item-count/1, Laptop-computer), (Item-count/1, Computer-mouse), (Item-count/1, Device))), (Background-view, (Room, Indoors, Ingestible-object, Furnishing, Display-device, Pen, Notebook))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Computing-device/Cellphone),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Ingestible-object,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Device/IO-device/Output-device/Display-device,Item/Object/Man-made-object/Device/Assistive-device/Writing-device/Pen,Item/Object/Man-made-object/Document/Notebook))",
+    "coco_id": "423488",
+    "nsd_id": "48681"
+  },
+  "shared0671_nsd48803": {
+    "hed_short": "(Foreground-view, (Item-count/1, Vehicle)), (Background-view, (Paved-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "161836",
+    "nsd_id": "48802"
+  },
+  "shared0672_nsd48833": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, Agent-trait/Adult)), (Item-count/1, (Human, Body, Agent-trait/Child)), ((Item-count, High), Man-made-object/Toy), ((Item-count, High), Building))), (Background-view, (Sloped-terrain, Plant, Outdoors, Mountain, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Child)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Building))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Mountain,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "424110",
+    "nsd_id": "48832"
+  },
+  "shared0673_nsd48840": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Grassy-terrain, Field, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "424138",
+    "nsd_id": "48839"
+  },
+  "shared0674_nsd49077": {
+    "hed_short": "(Foreground-view, (Item-count/3, Furnishing)), (Background-view, (Entrance, Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Entrance,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "425135",
+    "nsd_id": "49076"
+  },
+  "shared0675_nsd49153": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "163250",
+    "nsd_id": "49152"
+  },
+  "shared0676_nsd49157": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, Agent-trait/Adult)), (Item-count/2, (Human, Body, Male, Agent-trait/Child)), (Item-count/1, Path), ((Item-count, High), Animal))), (Background-view, (Hill, Plant, Outdoors, Grassy-terrain, Field, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Hill,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "163263",
+    "nsd_id": "49156"
+  },
+  "shared0677_nsd49235": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Furnishing), (Item-count/1, Laptop-computer), (Item-count/1, Computer-mouse), (Item-count/1, Cellphone), (Item-count/1, Book), (Item-count/1, Pen), (Item-count/1, Notebook))), (Background-view, (Room, Indoors, Man-made-object, Drawing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Cellphone),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Document/Book),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device/Writing-device/Pen),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Document/Notebook))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object,Item/Object/Man-made-object/Media/Visualization/Image/Drawing))",
+    "coco_id": "425712",
+    "nsd_id": "49234"
+  },
+  "shared0678_nsd49467": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Outdoors, Plant, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural))",
+    "coco_id": "164502",
+    "nsd_id": "49466"
+  },
+  "shared0679_nsd49481": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, (Face, Towards), Male, Agent-trait/Infant)), Move-upper-extremity), (Item-count/2, Man-made-object/Toy), ((Item-count, High), Icon))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Infant)),Action/Move/Move-body-part/Move-upper-extremity),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Media/Visualization/Image/Icon))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "164564",
+    "nsd_id": "49480"
+  },
+  "shared0680_nsd49623": {
+    "hed_short": "(Foreground-view, (Item-count/1, (Human, Body, Male, (Face, Towards), Agent-trait/Adult))), (Background-view, (Grassy-terrain, Furnishing, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "485595",
+    "nsd_id": "49622"
+  },
+  "shared0681_nsd49732": {
+    "hed_short": "(Foreground-view, (Item-count/3, Animal)), (Background-view, (Grassy-terrain, Field, Plant, Outdoors, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "427729",
+    "nsd_id": "49731"
+  },
+  "shared0682_nsd49924": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Agent-trait/Adolescent)), (Item-count/2, Man-made-object/Toy))), (Background-view, (Sloped-terrain, Plant, Mountain, Outdoors, Rural, Natural-feature/Sky, (Human, Body), Man-made-object/Toy))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adolescent)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Mountain,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Toy))",
+    "coco_id": "14269",
+    "nsd_id": "49923"
+  },
+  "shared0683_nsd49945": {
+    "hed_short": "(Foreground-view, (Item-count/1, Man-made-object)), (Background-view, (Grassy-terrain, Field, Outdoors, Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "428605",
+    "nsd_id": "49944"
+  },
+  "shared0684_nsd49956": {
+    "hed_short": "(Foreground-view, ((Item-count/4, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/3, Man-made-object/Toy)))), (Background-view, (Composite-terrain, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "166489",
+    "nsd_id": "49955"
+  },
+  "shared0685_nsd49958": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Towards), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors, Dirt-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Dirt-terrain))",
+    "coco_id": "166504",
+    "nsd_id": "49957"
+  },
+  "shared0686_nsd49970": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/1, Boat), (Item-count/1, (Human, Body)), Rocky-terrain)), (Background-view, (Outdoors, Natural-feature/Sky, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Boat),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),Property/Environmental-property/Terrain/Rocky-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "428691",
+    "nsd_id": "49969"
+  },
+  "shared0687_nsd49980": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Towards), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Composite-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "428726",
+    "nsd_id": "49979"
+  },
+  "shared0688_nsd50027": {
+    "hed_short": "(Foreground-view, ((Item-count/3, (Human, Body, Male, (Face, Towards), Agent-trait/Child)), ((Item-count, High), Man-made-object/Toy))), (Background-view, (Path, Dirt-terrain, Outdoors, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Child)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Path,Property/Environmental-property/Terrain/Dirt-terrain,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building))",
+    "coco_id": "166764",
+    "nsd_id": "50026"
+  },
+  "shared0689_nsd50115": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), ((Item-count, High), Plant))), (Background-view, (Dirt-terrain, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Dirt-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "508456",
+    "nsd_id": "50114"
+  },
+  "shared0690_nsd50171": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), (Item-count/1, Man-made-object))), (Background-view, (Plant, Outdoors, Sloped-terrain, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Sloped-terrain,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "43829",
+    "nsd_id": "50170"
+  },
+  "shared0691_nsd50501": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Furnishing), (Item-count/1, Laptop-computer), (Item-count/1, Computer-mouse), (Item-count/1, Keyboard), (Item-count/1, Tool))), (Background-view, (Painting, Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Tool))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Media/Visualization/Image/Painting,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "168690",
+    "nsd_id": "50500"
+  },
+  "shared0692_nsd50654": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), ((Item-count, High), Plant))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "169262",
+    "nsd_id": "50653"
+  },
+  "shared0693_nsd50735": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Train), Rocky-terrain)), (Background-view, (Outdoors, Plant, Building, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Vehicle/Train),Property/Environmental-property/Terrain/Rocky-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "431764",
+    "nsd_id": "50734"
+  },
+  "shared0694_nsd50756": {
+    "hed_short": "(Foreground-view, (Item-count/3, Animal)), (Background-view, (Outdoors, Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "431825",
+    "nsd_id": "50755"
+  },
+  "shared0695_nsd50812": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Outdoors, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building))",
+    "coco_id": "284987",
+    "nsd_id": "50811"
+  },
+  "shared0696_nsd50883": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Outdoors, Plant, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "28367",
+    "nsd_id": "50882"
+  },
+  "shared0697_nsd51052": {
+    "hed_short": "(Foreground-view, (Item-count/2, Furnishing)), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "433019",
+    "nsd_id": "51051"
+  },
+  "shared0698_nsd51053": {
+    "hed_short": "(Foreground-view, ((Item-count/3, 2D-Shape), (Item-count/2, Character))), (Background-view, (Plant, Outdoors, Natural-feature/Sky, Urban, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Geometric-object/2D-shape),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building))",
+    "coco_id": "433021",
+    "nsd_id": "51052"
+  },
+  "shared0699_nsd51063": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Furnishing), (Item-count/1, Laptop-computer), (Item-count/1, Computer-mouse), (Item-count/1, Keyboard), (Item-count/1, (Human, Body, Agent-trait/Adult)))), (Background-view, (Furnishing, Man-made-object, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "170917",
+    "nsd_id": "51062"
+  },
+  "shared0700_nsd51078": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Furnishing), (Item-count/3, Clothing))), (Background-view, (Grassy-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Clothing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "170968",
+    "nsd_id": "51077"
+  },
+  "shared0701_nsd51149": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Adult)), (Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)))), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "79701",
+    "nsd_id": "51148"
+  },
+  "shared0702_nsd51172": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Plant), ((Item-count, High), Ingestible-object))), (Background-view, (Outdoors, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building))",
+    "coco_id": "171328",
+    "nsd_id": "51171"
+  },
+  "shared0703_nsd51186": {
+    "hed_short": "(Foreground-view, (Item-count/1, Furnishing)), (Background-view, (Furnishing, Room, Indoors, Animal, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Biological-item/Organism/Animal,Item/Biological-item/Organism/Plant))",
+    "coco_id": "171374",
+    "nsd_id": "51185"
+  },
+  "shared0704_nsd51522": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/4, Furnishing), ((Item-count, High), Plant))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "420713",
+    "nsd_id": "51521"
+  },
+  "shared0705_nsd51746": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Animal), ((Item-count, High), Plant))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "28930",
+    "nsd_id": "51745"
+  },
+  "shared0706_nsd51789": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Animal), Grassy-terrain, Field)), (Background-view, (Plant, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "435902",
+    "nsd_id": "51788"
+  },
+  "shared0707_nsd51844": {
+    "hed_short": "(Foreground-view, (((Item-count/3, (Animal, Animal-agent)), Run), (Item-count/1, Path))), (Background-view, (Grassy-terrain, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Animal,Agent/Animal-agent)),Action/Move/Move-body-part/Move-lower-extremity/Run),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "173987",
+    "nsd_id": "51843"
+  },
+  "shared0708_nsd51908": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object))), (Item-count/1, River))), (Background-view, (Composite-terrain, Outdoors, (Human, Body, Agent-trait/Adult), (Human, Body, Agent-trait/Child), Plant, Path))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Child),Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Navigational-object/Path))",
+    "coco_id": "174213",
+    "nsd_id": "51907"
+  },
+  "shared0709_nsd51929": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Towards), Agent-trait/Child)), (Item-count/2, Tool), (Item-count/3, Word))), (Background-view, (Furnishing, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Tool),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors))",
+    "coco_id": "174303",
+    "nsd_id": "51928"
+  },
+  "shared0710_nsd51966": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Road))), (Background-view, (Plant, Paved-terrain, Mountain, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Natural-object/Natural-feature/Mountain,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "436578",
+    "nsd_id": "51965"
+  },
+  "shared0711_nsd51984": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors, Sloped-terrain, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Rural))",
+    "coco_id": "174504",
+    "nsd_id": "51983"
+  },
+  "shared0712_nsd51989": {
+    "hed_short": "(Foreground-view, ((Item-count/2, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "174522",
+    "nsd_id": "51988"
+  },
+  "shared0713_nsd52071": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Vehicle), (Item-count/2, Word))), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "291280",
+    "nsd_id": "52070"
+  },
+  "shared0714_nsd52217": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Paved-terrain, Outdoors, Natural-feature/Sky, (Human, Body), Man-made-object/Toy))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Toy))",
+    "coco_id": "437516",
+    "nsd_id": "52216"
+  },
+  "shared0715_nsd52303": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Grassy-terrain, Outdoors, Plant, Building, Road, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Navigational-object/Road,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "175715",
+    "nsd_id": "52302"
+  },
+  "shared0716_nsd52329": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing))), (Background-view, (Ingestible-object, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Ingestible-object,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "437967",
+    "nsd_id": "52328"
+  },
+  "shared0717_nsd52376": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, (Face, Towards), Agent-trait/Adult)), (Item-count/1, Animal))), (Background-view, (Grassy-terrain, Outdoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "438154",
+    "nsd_id": "52375"
+  },
+  "shared0718_nsd52395": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "176085",
+    "nsd_id": "52394"
+  },
+  "shared0719_nsd52528": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Car))), (Background-view, (Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "438751",
+    "nsd_id": "52527"
+  },
+  "shared0720_nsd52555": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Clock-face), ((Item-count, High), Building))), (Background-view, (Outdoors, Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Building))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "176728",
+    "nsd_id": "52554"
+  },
+  "shared0721_nsd52597": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Man-made-object), (Item-count/1, (Human, Body, Agent-trait/Adult)), (Item-count/2, Road), ((Item-count, High), Icon), (Item-count/1, Bicycle))), (Background-view, (Outdoors, Plant, Urban, Natural-feature/Sky, Man-made-object, Vehicle, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Navigational-object/Road),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Media/Visualization/Image/Icon),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Bicycle))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object,Item/Object/Man-made-object/Vehicle,Item/Object/Man-made-object/Building))",
+    "coco_id": "176873",
+    "nsd_id": "52596"
+  },
+  "shared0722_nsd52599": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Away-from), Agent-trait/Adult)), (Item-count/2, Furnishing))), (Background-view, (Paved-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "73172",
+    "nsd_id": "52598"
+  },
+  "shared0723_nsd52653": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Furnishing)), (Background-view, (Photograph, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Media/Visualization/Image/Photograph,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "439241",
+    "nsd_id": "52652"
+  },
+  "shared0724_nsd52893": {
+    "hed_short": "(Foreground-view, ((((Item-count, High), ((Human, Human-agent), Body)), (Action/Ride, ((Item-count, High), (Animal, Animal-agent))), Walk), Terrain/Sand)), (Background-view, (Natural-feature/Ocean, Natural-feature/Sky, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body)),(Action/Ride,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Animal,Agent/Animal-agent))),Action/Move/Move-body-part/Move-lower-extremity/Walk),Property/Environmental-property/Terrain/Sand)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "178031",
+    "nsd_id": "52892"
+  },
+  "shared0725_nsd52932": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object))",
+    "coco_id": "440334",
+    "nsd_id": "52931"
+  },
+  "shared0726_nsd52991": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), (Item-count/1, Path), (Item-count/1, Roof), Rocky-terrain)), (Background-view, (Natural-feature/Sky, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Roof),Property/Environmental-property/Terrain/Rocky-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "178423",
+    "nsd_id": "52990"
+  },
+  "shared0727_nsd53053": {
+    "hed_short": "(Foreground-view, (Item-count/1, Clock-face)), (Background-view, (Pattern))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Geometric-object/Pattern))",
+    "coco_id": "440792",
+    "nsd_id": "53052"
+  },
+  "shared0728_nsd53071": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/4, Man-made-object), ((Item-count, High), (Human, Body)), (Item-count/2, Path))), (Background-view, (Paved-terrain, Plant, Outdoors, Urban, Natural-feature/Sky, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object/Building))",
+    "coco_id": "395740",
+    "nsd_id": "53070"
+  },
+  "shared0729_nsd53153": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Furnishing), (Item-count/2, Man-made-object))), (Background-view, (Room, Indoors, Man-made-object, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "179019",
+    "nsd_id": "53152"
+  },
+  "shared0730_nsd53156": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, (Item-count/1, Female), (Item-count/1, Male))), (Item-count/1, Path), (Item-count/1, Roof), (Item-count/1, Man-made-object))), (Background-view, (Outdoors, Paved-terrain, Urban, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Property/Agent-property/Agent-trait/Sex/Female),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Property/Agent-property/Agent-trait/Sex/Male))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Roof),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building))",
+    "coco_id": "441172",
+    "nsd_id": "53155"
+  },
+  "shared0731_nsd53158": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Animal), (Item-count/1, (Human, Body, Female, (Face, Towards), Agent-trait/Adult)), (Item-count/1, Furnishing))), (Background-view, (Rocky-terrain, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Rocky-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "179034",
+    "nsd_id": "53157"
+  },
+  "shared0732_nsd53271": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, (Face, Towards), Agent-trait/Adult)), (Item-count/2, Man-made-object/Toy))), (Background-view, (Outdoors, Plant, Sloped-terrain, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Rural))",
+    "coco_id": "179480",
+    "nsd_id": "53270"
+  },
+  "shared0733_nsd53371": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Agent-trait/Child)), (Item-count/1, Man-made-object/Toy))), (Background-view, (Natural-feature/Ocean, Outdoors, Natural-feature/Sky, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "179914",
+    "nsd_id": "53370"
+  },
+  "shared0734_nsd53490": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/2, Furnishing), (Item-count/1, Assistive-device))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "442489",
+    "nsd_id": "53489"
+  },
+  "shared0735_nsd53512": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "180410",
+    "nsd_id": "53511"
+  },
+  "shared0736_nsd53571": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Outdoors, Plant, Sloped-terrain, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Sloped-terrain,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "180609",
+    "nsd_id": "53570"
+  },
+  "shared0737_nsd53728": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), (Item-count/2, Word), Rocky-terrain)), (Background-view, (Plant, Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Word),Property/Environmental-property/Terrain/Rocky-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "443377",
+    "nsd_id": "53727"
+  },
+  "shared0738_nsd53729": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Assistive-device), ((Item-count, High), Plant), ((Item-count, High), Ingestible-object)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object)))",
+    "coco_id": "204969",
+    "nsd_id": "53728"
+  },
+  "shared0739_nsd53774": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Desktop-computer), (Item-count/1, Keyboard), ((Item-count, High), Furnishing))), (Background-view, (Book, Drawing, Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Document/Book,Item/Object/Man-made-object/Media/Visualization/Image/Drawing,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "443575",
+    "nsd_id": "53773"
+  },
+  "shared0740_nsd53859": {
+    "hed_short": "(Foreground-view, (Item-count/3, Furnishing)), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "161354",
+    "nsd_id": "53858"
+  },
+  "shared0741_nsd53882": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Dirt-terrain, Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Dirt-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "443940",
+    "nsd_id": "53881"
+  },
+  "shared0742_nsd53892": {
+    "hed_short": "(Foreground-view, (((Item-count/3, ((Human, Human-agent), Body, Male, (Face, Towards), Agent-trait/Adolescent)), (Action/Ride, (Item-count/3, Bicycle))), (Item-count/1, Path), ((Item-count, High), Plant), (Item-count/1, Furnishing))), (Background-view, (Building, Urban, Natural-feature/Sky, River, Composite-terrain, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/3,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adolescent)),(Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Vehicle/Bicycle))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Natural-object/Natural-feature/River,Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "181837",
+    "nsd_id": "53891"
+  },
+  "shared0743_nsd54079": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Entrance), (Item-count/1, Drawing), ((Item-count, High), Furnishing))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Entrance),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Image/Drawing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "189388",
+    "nsd_id": "54078"
+  },
+  "shared0744_nsd54148": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, (Face, Away-from), Agent-trait/Adult)), (Item-count/1, Cellphone))), (Background-view, (Waterfall, Plant, Building, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Cellphone))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Waterfall,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "182799",
+    "nsd_id": "54147"
+  },
+  "shared0745_nsd54258": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Grassy-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "445351",
+    "nsd_id": "54257"
+  },
+  "shared0746_nsd54362": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/2, Clock-face))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "445726",
+    "nsd_id": "54361"
+  },
+  "shared0747_nsd54390": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), ((Item-count, High), Plant))), (Background-view, (Outdoors, Rural, Composite-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Property/Environmental-property/Terrain/Composite-terrain))",
+    "coco_id": "183719",
+    "nsd_id": "54389"
+  },
+  "shared0748_nsd54644": {
+    "hed_short": "(Foreground-view, (Item-count/1, Vehicle)), (Background-view, (Road, Paved-terrain, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Road,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "184822",
+    "nsd_id": "54643"
+  },
+  "shared0749_nsd54684": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Paved-terrain, (Human, Body), Man-made-object/Toy, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Toy,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "447130",
+    "nsd_id": "54683"
+  },
+  "shared0750_nsd54699": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy))), Sloped-terrain)), (Background-view, (Natural-feature/Sky, Rural, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),Property/Environmental-property/Terrain/Sloped-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural,Property/Environmental-property/Outdoors))",
+    "coco_id": "447182",
+    "nsd_id": "54698"
+  },
+  "shared0751_nsd54744": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/2, Furnishing), (Item-count/1, Man-made-object), (Item-count/1, Assistive-device))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "185225",
+    "nsd_id": "54743"
+  },
+  "shared0752_nsd54813": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Towards), Agent-trait/Adolescent)), (Play, (Item-count/1, Man-made-object/Toy))), ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adolescent)), (Play, (Item-count/1, Man-made-object/Toy))), (Item-count/1, (Human, Body, Male, Agent-trait/Adult)), (Item-count/1, Character))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "36151",
+    "nsd_id": "54812"
+  },
+  "shared0753_nsd54825": {
+    "hed_short": "(Foreground-view, (Item-count/2, Furnishing)), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "6178",
+    "nsd_id": "54824"
+  },
+  "shared0754_nsd54914": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/1, Runway), (Item-count/2, Icon))), (Background-view, (Grassy-terrain, Building, Natural-feature/Sky, Urban, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Runway),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Media/Visualization/Image/Icon))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Man-made-object/Building,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Property/Environmental-property/Outdoors))",
+    "coco_id": "185888",
+    "nsd_id": "54913"
+  },
+  "shared0755_nsd54960": {
+    "hed_short": "(Foreground-view, (((Item-count/3, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/3, Man-made-object/Toy))), (Item-count/1, Character))), (Background-view, (Outdoors, Composite-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/3,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Composite-terrain))",
+    "coco_id": "55764",
+    "nsd_id": "54959"
+  },
+  "shared0756_nsd55006": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), Grassy-terrain, (Item-count/1, River))), (Background-view, (Natural-feature/Sky, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),Property/Environmental-property/Terrain/Grassy-terrain,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "448401",
+    "nsd_id": "55005"
+  },
+  "shared0757_nsd55108": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Adult)), (Item-count/1, Cellphone)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Cellphone)))",
+    "coco_id": "442666",
+    "nsd_id": "55107"
+  },
+  "shared0758_nsd55164": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Furnishing), (Item-count/1, Entrance))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Entrance))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "186828",
+    "nsd_id": "55163"
+  },
+  "shared0759_nsd55406": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy))), (Item-count/1, Word))), (Background-view, (Outdoors, Composite-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Composite-terrain))",
+    "coco_id": "449914",
+    "nsd_id": "55405"
+  },
+  "shared0760_nsd55409": {
+    "hed_short": "(Foreground-view, ((Item-count/3, 2D-Shape), (Item-count/1, Word), (Item-count/4, Car), (Item-count/1, Road))), (Background-view, (Building, Plant, Outdoors, Natural-feature/Sky, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Geometric-object/2D-shape),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Vehicle/Car),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban))",
+    "coco_id": "276853",
+    "nsd_id": "55408"
+  },
+  "shared0761_nsd55527": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/1, Roof), (Item-count/1, Runway), (Item-count/2, (Human, Body, Agent-trait/Adult)), (Item-count/1, Icon))), (Background-view, (Outdoors, Paved-terrain, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Roof),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Runway),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Image/Icon))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "188225",
+    "nsd_id": "55526"
+  },
+  "shared0762_nsd55650": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Animal), Terrain/Sand)), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Sand)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "188660",
+    "nsd_id": "55649"
+  },
+  "shared0763_nsd55670": {
+    "hed_short": "(Foreground-view, ((Item-count/3, (Human, Body, (Face, Towards), Female, Agent-trait/Adult)), ((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing), ((Item-count, High), Assistive-device), (Item-count/4, Character))), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Device/Assistive-device),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "450864",
+    "nsd_id": "55669"
+  },
+  "shared0764_nsd55679": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy))), (Item-count/2, Character))), (Background-view, (Outdoors, Composite-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Composite-terrain))",
+    "coco_id": "450903",
+    "nsd_id": "55678"
+  },
+  "shared0765_nsd55681": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/2, Furnishing))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "450914",
+    "nsd_id": "55680"
+  },
+  "shared0766_nsd55858": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, Agent-trait/Child)), (Item-count/1, Man-made-object/Toy))), (Background-view, (Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant))",
+    "coco_id": "451680",
+    "nsd_id": "55857"
+  },
+  "shared0767_nsd55934": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Female, Agent-trait/Adult)), (Action/Ride, (Item-count/1, Bicycle))), (Item-count/1, Building), (Item-count/1, Path), ((Item-count, High), Furnishing))), (Background-view, (Outdoors, Plant, Paved-terrain, Natural-feature/Sky, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Bicycle))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban))",
+    "coco_id": "189794",
+    "nsd_id": "55933"
+  },
+  "shared0768_nsd55969": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Vehicle), (Item-count/1, Car))), (Background-view, (Paved-terrain, Building, Outdoors, Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "189888",
+    "nsd_id": "55968"
+  },
+  "shared0769_nsd55970": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Furnishing)), (Background-view, (Photograph, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Media/Visualization/Image/Photograph,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "189893",
+    "nsd_id": "55969"
+  },
+  "shared0770_nsd56043": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Grassy-terrain, Outdoors, Plant, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural))",
+    "coco_id": "452341",
+    "nsd_id": "56042"
+  },
+  "shared0771_nsd56067": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, River))), (Background-view, (Rocky-terrain, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Rocky-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "190271",
+    "nsd_id": "56066"
+  },
+  "shared0772_nsd56127": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Sloped-terrain, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "190487",
+    "nsd_id": "56126"
+  },
+  "shared0773_nsd56155": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Clock-face), (Item-count/1, Sculpture), (Item-count/1, Building))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Sculpture),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "303133",
+    "nsd_id": "56154"
+  },
+  "shared0774_nsd56270": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Animal), ((Item-count, High), Plant))), (Background-view, (Outdoors, Rural, Dirt-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Property/Environmental-property/Terrain/Dirt-terrain))",
+    "coco_id": "191005",
+    "nsd_id": "56269"
+  },
+  "shared0775_nsd56291": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Towards), Agent-trait/Adult)), (Item-count/1, Vehicle))), (Background-view, (Outdoors, Road))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Navigational-object/Road))",
+    "coco_id": "453221",
+    "nsd_id": "56290"
+  },
+  "shared0776_nsd56315": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Reach, (Item-count/1, (Animal, Animal-agent)), Bite)), (Item-count/1, Pen))), (Background-view, (Composite-terrain, Plant, Roof, Outdoors, Natural-feature/Sky, Animal))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Move/Move-body-part/Move-upper-extremity/Reach,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent)),Action/Move/Move-body-part/Move-face/Bite)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device/Writing-device/Pen))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building/Roof,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Item/Biological-item/Organism/Animal))",
+    "coco_id": "468771",
+    "nsd_id": "56314"
+  },
+  "shared0777_nsd56419": {
+    "hed_short": "(Foreground-view, ((Item-count/3, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/3, Man-made-object/Toy)))), (Background-view, (Furnishing, Composite-terrain, Outdoors, (Human, Body, Agent-trait/Adult)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)))",
+    "coco_id": "453682",
+    "nsd_id": "56418"
+  },
+  "shared0778_nsd56455": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), Rocky-terrain, ((Item-count, High), Plant))), (Background-view, (Outdoors, Rural, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Rocky-terrain,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Rural,Item/Biological-item/Organism/Plant))",
+    "coco_id": "191686",
+    "nsd_id": "56454"
+  },
+  "shared0779_nsd56472": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing), (Item-count/1, Assistive-device))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "191740",
+    "nsd_id": "56471"
+  },
+  "shared0780_nsd56671": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/1, Vehicle))), (Background-view, (Paved-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "192576",
+    "nsd_id": "56670"
+  },
+  "shared0781_nsd56682": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "192631",
+    "nsd_id": "56681"
+  },
+  "shared0782_nsd56696": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Child)), (Item-count/1, (Human, Body, (Face, Away-from), Female, Agent-trait/Child)), (Item-count/2, Assistive-device), ((Item-count, High), Icon))), (Background-view, (Furnishing, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Assistive-device),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Media/Visualization/Image/Icon))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors))",
+    "coco_id": "454830",
+    "nsd_id": "56695"
+  },
+  "shared0783_nsd56724": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Desktop-computer), (Item-count/1, Keyboard), (Item-count/1, Computer-mouse))), (Background-view, (Room, Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "454915",
+    "nsd_id": "56723"
+  },
+  "shared0784_nsd56752": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Furnishing), (Item-count/1, Desktop-computer), (Item-count/1, Keyboard), (Item-count/1, Computer-mouse), (Item-count/1, Loudspeaker))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Output-device/Auditory-device/Loudspeaker))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "455020",
+    "nsd_id": "56751"
+  },
+  "shared0785_nsd56783": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Furnishing), ((Item-count, High), Plant))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "119550",
+    "nsd_id": "56782"
+  },
+  "shared0786_nsd56785": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Towards), Agent-trait/Child)), (Item-count/1, Man-made-object))), (Background-view, (Paved-terrain, Outdoors, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban))",
+    "coco_id": "193023",
+    "nsd_id": "56784"
+  },
+  "shared0787_nsd56851": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adolescent)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Paved-terrain, Outdoors, Building, Plant, Urban, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "193318",
+    "nsd_id": "56850"
+  },
+  "shared0788_nsd56868": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "193373",
+    "nsd_id": "56867"
+  },
+  "shared0789_nsd56912": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/4, Plant))), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "455657",
+    "nsd_id": "56911"
+  },
+  "shared0790_nsd56949": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Reach, ((Item-count, High), Ingestible-object))), ((Item-count, High), Furnishing))), (Background-view, (Indoors, Furnishing, Room, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Move/Move-body-part/Move-upper-extremity/Reach,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object))),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Item/Object/Man-made-object))",
+    "coco_id": "455799",
+    "nsd_id": "56948"
+  },
+  "shared0791_nsd57047": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Furnishing)), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "194054",
+    "nsd_id": "57046"
+  },
+  "shared0792_nsd57061": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Clock-face), (Item-count/1, Building), (Item-count/3, Man-made-object), (Item-count/1, Plant))), (Background-view, ((Human, Body), Car, Outdoors, Natural-feature/Sky, Urban, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Vehicle/Car,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building))",
+    "coco_id": "194108",
+    "nsd_id": "57060"
+  },
+  "shared0793_nsd57436": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Towards), Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy))), (Item-count/3, Icon))), (Background-view, (Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Media/Visualization/Image/Icon))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "338439",
+    "nsd_id": "57435"
+  },
+  "shared0794_nsd57444": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/2, Clock-face), (Item-count/1, River))), (Background-view, (Plant, Outdoors, Natural-feature/Sky, Urban, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building))",
+    "coco_id": "195650",
+    "nsd_id": "57443"
+  },
+  "shared0795_nsd57479": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "195768",
+    "nsd_id": "57478"
+  },
+  "shared0796_nsd57543": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy))), (Item-count/1, Word), (Item-count/2, Character))), (Background-view, (Outdoors, Composite-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Composite-terrain))",
+    "coco_id": "338501",
+    "nsd_id": "57542"
+  },
+  "shared0797_nsd57554": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/1, Desktop-computer), ((Item-count, High), Man-made-object))), (Background-view, (Room, Indoors, Entrance))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Building/Entrance))",
+    "coco_id": "458178",
+    "nsd_id": "57553"
+  },
+  "shared0798_nsd57649": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Towards), Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy))), ((Item-count, High), Icon))), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Media/Visualization/Image/Icon))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "196365",
+    "nsd_id": "57648"
+  },
+  "shared0799_nsd57651": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Furnishing), (Item-count/1, Plant))), (Background-view, (Indoors, Room))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Building/Room))",
+    "coco_id": "196368",
+    "nsd_id": "57650"
+  },
+  "shared0800_nsd57682": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing), (Item-count/2, Assistive-device))), (Background-view, (Indoors, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Assistive-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "458616",
+    "nsd_id": "57681"
+  },
+  "shared0801_nsd57823": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Assistive-device)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device)))",
+    "coco_id": "459190",
+    "nsd_id": "57822"
+  },
+  "shared0802_nsd57839": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Grassy-terrain, Field, Outdoors, Plant, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "197118",
+    "nsd_id": "57838"
+  },
+  "shared0803_nsd57907": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), (Data-property, Plant))), (Background-view, (Outdoors, Composite-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),(Property/Data-property,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Composite-terrain))",
+    "coco_id": "197401",
+    "nsd_id": "57906"
+  },
+  "shared0804_nsd58097": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Grassy-terrain, Field, Outdoors, Plant, Rural, Animal))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural,Item/Biological-item/Organism/Animal))",
+    "coco_id": "460236",
+    "nsd_id": "58096"
+  },
+  "shared0805_nsd58145": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing), (Item-count/2, Assistive-device), (Item-count/3, Word)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Assistive-device),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Language-item/Word)))",
+    "coco_id": "460408",
+    "nsd_id": "58144"
+  },
+  "shared0806_nsd58165": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Icon), (Item-count/3, 2D-Shape), (Item-count/1, Road))), (Background-view, (Plant, Vehicle, Natural-feature/Sky, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Media/Visualization/Image/Icon),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Geometric-object/2D-shape),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Vehicle,Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object))",
+    "coco_id": "198319",
+    "nsd_id": "58164"
+  },
+  "shared0807_nsd58188": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, (Face, Towards), Male, Agent-trait/Adult)), Walk), (Item-count/1, (Human, Body, Male, Agent-trait/Adult)), (Item-count/1, (Human, Body, Agent-trait/Adult, Female)), (Item-count/2, Man-made-object))), (Background-view, (Outdoors, Paved-terrain, Building, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),Action/Move/Move-body-part/Move-lower-extremity/Walk),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult,Property/Agent-property/Agent-trait/Sex/Female)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Man-made-object/Building,Property/Environmental-property/Urban))",
+    "coco_id": "397815",
+    "nsd_id": "58187"
+  },
+  "shared0808_nsd58405": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Desktop-computer), (Item-count/1, Keyboard), (Item-count/1, Computer-mouse), ((Item-count, High), Photograph), (Item-count/1, Furnishing), (Item-count/2, Assistive-device), ((Item-count, High), Notebook))), (Background-view, (Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Media/Visualization/Image/Photograph),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Assistive-device),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Document/Notebook))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "461428",
+    "nsd_id": "58404"
+  },
+  "shared0809_nsd58669": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Vehicle), (Item-count/1, Road), (Item-count/1, Word))), (Background-view, (Composite-terrain, Plant, Outdoors, Urban, Car, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Man-made-object/Vehicle/Car,Item/Object/Man-made-object/Building))",
+    "coco_id": "462505",
+    "nsd_id": "58668"
+  },
+  "shared0810_nsd58682": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/2, Plant))), (Background-view, (Natural-feature/Sky, Outdoors, Urban, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building))",
+    "coco_id": "200391",
+    "nsd_id": "58681"
+  },
+  "shared0811_nsd59024": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (River, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/River,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "201722",
+    "nsd_id": "59023"
+  },
+  "shared0812_nsd59040": {
+    "hed_short": "(Foreground-view, (Item-count/3, Animal)), (Background-view, (Composite-terrain, Outdoors, Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "201758",
+    "nsd_id": "59039"
+  },
+  "shared0813_nsd59047": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), (Item-count/2, Word), Rocky-terrain)), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Word),Property/Environmental-property/Terrain/Rocky-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "557920",
+    "nsd_id": "59046"
+  },
+  "shared0814_nsd59080": {
+    "hed_short": "(Foreground-view, ((Item-count/3, (Human, Body, Male, Agent-trait/Adult)), (Item-count/1, (Human, Body, Female, Agent-trait/Child)), (Item-count/4, Animal), (Item-count/1, Furnishing))), (Background-view, (Outdoors, Paved-terrain, River, Building, Boat, Urban, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Natural-object/Natural-feature/River,Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Vehicle/Boat,Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "201969",
+    "nsd_id": "59079"
+  },
+  "shared0815_nsd59092": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Boat), (Item-count/1, Word), (Item-count/2, Character))), (Background-view, (Natural-feature/Ocean, Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Vehicle/Boat),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "202050",
+    "nsd_id": "59091"
+  },
+  "shared0816_nsd59195": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Composite-terrain, Outdoors, (Human, Body), Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Biological-item/Organism/Plant))",
+    "coco_id": "464616",
+    "nsd_id": "59194"
+  },
+  "shared0817_nsd59285": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Adult)), (Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), (Item-count/2, (Human, Body, Male, Agent-trait/Adult)), (Item-count/1, Man-made-object/Toy))), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "202805",
+    "nsd_id": "59284"
+  },
+  "shared0818_nsd59420": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Away-from), Agent-trait/Adolescent)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Plant, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "465412",
+    "nsd_id": "59419"
+  },
+  "shared0819_nsd59421": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "298139",
+    "nsd_id": "59420"
+  },
+  "shared0820_nsd59586": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Laptop-computer), (Item-count/1, Computer-mouse))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "203937",
+    "nsd_id": "59585"
+  },
+  "shared0821_nsd59596": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, Male, (Face, Away-from), Agent-trait/Child)), (Item-count/1, (Human, Body, Male, Agent-trait/Child)), (Item-count/1, Tool))), (Background-view, (Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Tool))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "77686",
+    "nsd_id": "59595"
+  },
+  "shared0822_nsd59632": {
+    "hed_short": "(Foreground-view, (Item-count/3, Animal)), (Background-view, (Indoors, Paved-terrain, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Biological-item/Organism/Plant))",
+    "coco_id": "466265",
+    "nsd_id": "59631"
+  },
+  "shared0823_nsd59700": {
+    "hed_short": "(Foreground-view, ((Item-count/3, (Human, Body, (Face, Towards), Female, Agent-trait/Adult)), (Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), ((Item-count, High), Man-made-object/Toy))), (Background-view, (Outdoors, Sloped-terrain, Plant, Rural, Natural-feature/Sky, (Human, Body), Machine))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Sloped-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Device/Machine))",
+    "coco_id": "204422",
+    "nsd_id": "59699"
+  },
+  "shared0824_nsd59818": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Plant))), (Background-view, (Outdoors, Grassy-terrain, Field))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field))",
+    "coco_id": "204806",
+    "nsd_id": "59817"
+  },
+  "shared0825_nsd59995": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body)), ((Item-count, High), Man-made-object/Toy), ((Item-count, High), Man-made-object), Terrain/Sand)), (Background-view, (Outdoors, Plant, Natural-feature/Ocean, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object),Property/Environmental-property/Terrain/Sand)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Man-made-object/Building))",
+    "coco_id": "467646",
+    "nsd_id": "59994"
+  },
+  "shared0826_nsd60095": {
+    "hed_short": "(Foreground-view, (Item-count/2, Furnishing)), (Background-view, (Room, Indoors, Furnishing, Entrance))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Entrance))",
+    "coco_id": "205875",
+    "nsd_id": "60094"
+  },
+  "shared0827_nsd60120": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body)), ((Item-count, High), Furnishing))), (Background-view, (Train, Paved-terrain, Outdoors, Natural-feature/Sky, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Vehicle/Train,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban))",
+    "coco_id": "296474",
+    "nsd_id": "60119"
+  },
+  "shared0828_nsd60187": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Furnishing), (Item-count/1, Path), ((Item-count, High), Plant))), (Background-view, (Outdoors, Urban, Furnishing, Building, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "468394",
+    "nsd_id": "60186"
+  },
+  "shared0829_nsd60252": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), ((Item-count, High), Building), ((Item-count, High), (Human, Body)))), (Background-view, (Plant, Paved-terrain, Natural-feature/Sky, Urban, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Building),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Property/Environmental-property/Outdoors))",
+    "coco_id": "206467",
+    "nsd_id": "60251"
+  },
+  "shared0830_nsd60306": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, (Face, Away-from), Male, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy))), ((Item-count/1, ((Human, Human-agent), Body, (Face, Away-from), Female, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "468825",
+    "nsd_id": "60305"
+  },
+  "shared0831_nsd60457": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object))",
+    "coco_id": "469445",
+    "nsd_id": "60456"
+  },
+  "shared0832_nsd60506": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Animal), (Item-count/1, River), ((Item-count, High), Plant))), (Background-view, (Plant, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "203615",
+    "nsd_id": "60505"
+  },
+  "shared0833_nsd60520": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Car), (Item-count/1, Road), ((Item-count/1, (Animal, Animal-agent)), Walk))), (Background-view, (Composite-terrain, Outdoors, Plant, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent)),Action/Move/Move-body-part/Move-lower-extremity/Walk))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "207549",
+    "nsd_id": "60519"
+  },
+  "shared0834_nsd60554": {
+    "hed_short": "(Foreground-view, ((Item-count/1, 2D-shape), (Item-count/1, Man-made-object))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Geometric-object/2D-shape),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "469816",
+    "nsd_id": "60553"
+  },
+  "shared0835_nsd60726": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, Agent-trait/Adult)), (Item-count/1, Vehicle), (Item-count/1, Road))), (Background-view, (Building, Outdoors, Plant, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "129143",
+    "nsd_id": "60725"
+  },
+  "shared0836_nsd60835": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Outdoors, Plant, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural))",
+    "coco_id": "470907",
+    "nsd_id": "60834"
+  },
+  "shared0837_nsd60846": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Furnishing), (Item-count/1, Loudspeaker), (Item-count/2, Drawing), (Item-count/1, Book), (Item-count/1, Tool))), (Background-view, (Room, Indoors, Display-device))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Output-device/Auditory-device/Loudspeaker),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Media/Visualization/Image/Drawing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Document/Book),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Tool))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Device/IO-device/Output-device/Display-device))",
+    "coco_id": "208805",
+    "nsd_id": "60845"
+  },
+  "shared0838_nsd60868": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Car))), (Background-view, (Urban, Car))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Urban,Item/Object/Man-made-object/Vehicle/Car))",
+    "coco_id": "208849",
+    "nsd_id": "60867"
+  },
+  "shared0839_nsd60979": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Towards), Agent-trait/Adult)), (Item-count/1, Ingestible-object), (Item-count/1, Furnishing))), (Background-view, (Furnishing, Man-made-object/Toy, Book, Room, Indoors, Ingestible-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Toy,Item/Object/Man-made-object/Document/Book,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Ingestible-object))",
+    "coco_id": "209229",
+    "nsd_id": "60978"
+  },
+  "shared0840_nsd61123": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Car))), (Background-view, (Grassy-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "471871",
+    "nsd_id": "61122"
+  },
+  "shared0841_nsd61134": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Animal), Grassy-terrain, Field)), (Background-view, (Building, Outdoors, Plant, Rural, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "34961",
+    "nsd_id": "61133"
+  },
+  "shared0842_nsd61178": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body)), (Item-count/1, River), (Item-count/2, Man-made-object), ((Item-count, High), Plant))), (Background-view, (Mountain, Outdoors, Plant, Building, Boat, Natural-feature/Sky, Grassy-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Mountain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Vehicle/Boat,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Terrain/Grassy-terrain))",
+    "coco_id": "209919",
+    "nsd_id": "61177"
+  },
+  "shared0843_nsd61217": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/2, Plant))), (Background-view, (Entrance, Room, Indoors, Painting))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Entrance,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Media/Visualization/Image/Painting))",
+    "coco_id": "210065",
+    "nsd_id": "61216"
+  },
+  "shared0844_nsd61511": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "341033",
+    "nsd_id": "61510"
+  },
+  "shared0845_nsd61514": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), (Item-count/1, Plant), Paved-terrain)), (Background-view, (Building, Plant, Natural-feature/Sky, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant),Property/Environmental-property/Terrain/Paved-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban))",
+    "coco_id": "211198",
+    "nsd_id": "61513"
+  },
+  "shared0846_nsd61678": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, (Face, Towards), Female, Agent-trait/Adult)), Walk), (Item-count/1, Cellphone))), (Background-view, (Paved-terrain, Outdoors, Plant, Furnishing, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),Action/Move/Move-body-part/Move-lower-extremity/Walk),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Cellphone))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Urban))",
+    "coco_id": "474024",
+    "nsd_id": "61677"
+  },
+  "shared0847_nsd61739": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), ((Item-count, High), Plant))), (Background-view, (Entrance, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Entrance,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "207833",
+    "nsd_id": "61738"
+  },
+  "shared0848_nsd61749": {
+    "hed_short": "(Foreground-view, (Item-count/1, (Human, Body, Male, (Face, Away-from), Agent-trait/Adult))), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "474353",
+    "nsd_id": "61748"
+  },
+  "shared0849_nsd61753": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Laptop-computer), (Item-count/3, Furnishing))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "212229",
+    "nsd_id": "61752"
+  },
+  "shared0850_nsd61798": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), (Item-count/1, Car))), (Background-view, (Urban, Man-made-object, Car))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Car))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Urban,Item/Object/Man-made-object,Item/Object/Man-made-object/Vehicle/Car))",
+    "coco_id": "212380",
+    "nsd_id": "61797"
+  },
+  "shared0851_nsd61802": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Animal), (Item-count/1, River))), (Background-view, (Grassy-terrain, Field, Mountain, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Object/Natural-object/Natural-feature/Mountain,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "474545",
+    "nsd_id": "61801"
+  },
+  "shared0852_nsd61810": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Ingestible-object)), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "212440",
+    "nsd_id": "61809"
+  },
+  "shared0853_nsd61874": {
+    "hed_short": "(Foreground-view, (Item-count/1, Clock-face)), (Background-view, (Outdoors, Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "474827",
+    "nsd_id": "61873"
+  },
+  "shared0854_nsd61973": {
+    "hed_short": "(Foreground-view, (Item-count/4, Ingestible-object)), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Ingestible-object)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "475236",
+    "nsd_id": "61972"
+  },
+  "shared0855_nsd62007": {
+    "hed_short": "(Foreground-view, ((Item-count/1, River), (Item-count/1, Boat))), (Background-view, (Natural-feature/Sky, Urban, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Boat))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building))",
+    "coco_id": "122923",
+    "nsd_id": "62006"
+  },
+  "shared0856_nsd62016": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/1, Entrance), (Item-count/3, Man-made-object))), (Background-view, (Room, Indoors, Furnishing, Plant, Entrance))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Entrance),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building/Entrance))",
+    "coco_id": "213288",
+    "nsd_id": "62015"
+  },
+  "shared0857_nsd62210": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/3, Building), (Item-count/1, Path))), (Background-view, (Outdoors, Natural-feature/Sky, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban))",
+    "coco_id": "213988",
+    "nsd_id": "62209"
+  },
+  "shared0858_nsd62229": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Aircraft), ((Item-count, High), Vehicle), (Item-count/1, (Human, Body, Agent-trait/Adult)), (Item-count/1, Runway))), (Background-view, (Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle/Aircraft),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Runway))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "214059",
+    "nsd_id": "62228"
+  },
+  "shared0859_nsd62276": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing)))",
+    "coco_id": "476380",
+    "nsd_id": "62275"
+  },
+  "shared0860_nsd62303": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Indoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "476481",
+    "nsd_id": "62302"
+  },
+  "shared0861_nsd62366": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), Walk), (Item-count/2, Train), (Item-count/1, Path), (Item-count/3, Plant))), (Background-view, (Plant, Outdoors,  Mountain, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),Action/Move/Move-body-part/Move-lower-extremity/Walk),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Vehicle/Train),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Mountain,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "560054",
+    "nsd_id": "62365"
+  },
+  "shared0862_nsd62480": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, Male, Agent-trait/Adult)), (Item-count/1, (Human, Body, Male, (Face, Away-from), Agent-trait/Adult)), ((Item-count, High), Furnishing))), (Background-view, (Furnishing, Room, Indoors, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object))",
+    "coco_id": "215023",
+    "nsd_id": "62479"
+  },
+  "shared0863_nsd62545": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "215291",
+    "nsd_id": "62544"
+  },
+  "shared0864_nsd62562": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Furnishing), (Item-count/2, Desktop-computer), (Item-count/1, Keyboard), (Item-count/1, Computer-mouse), (Item-count/2, Loudspeaker), (Item-count/2, Laptop-computer))), (Background-view, (Photograph,  Man-made-object, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/IO-device/Output-device/Auditory-device/Loudspeaker),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Media/Visualization/Image/Photograph,Item/Object/Man-made-object,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "385417",
+    "nsd_id": "62561"
+  },
+  "shared0865_nsd62684": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Man-made-object), (Item-count/1, Road), (Item-count/1, Word))), (Background-view, (Car, Building, Paved-terrain, Outdoors, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Vehicle/Car,Item/Object/Man-made-object/Building,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban))",
+    "coco_id": "35972",
+    "nsd_id": "62683"
+  },
+  "shared0866_nsd62749": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Natural-feature/Ocean, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "216029",
+    "nsd_id": "62748"
+  },
+  "shared0867_nsd62961": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing), (Item-count/1, (Human, Body, Female)), (Item-count/1, Assistive-device))), (Background-view, (Furnishing, Indoors, Assistive-device))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Device/Assistive-device))",
+    "coco_id": "479035",
+    "nsd_id": "62960"
+  },
+  "shared0868_nsd63082": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/1, Clock-face))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "444880",
+    "nsd_id": "63081"
+  },
+  "shared0869_nsd63183": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Desktop-computer), (Item-count/1, Keyboard), (Item-count/1, Computer-mouse), (Item-count/1, Notebook), (Item-count/1, Pen), (Item-count/1, Furnishing))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Document/Notebook),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device/Writing-device/Pen),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "294744",
+    "nsd_id": "63182"
+  },
+  "shared0870_nsd63346": {
+    "hed_short": "(Foreground-view, ((Item-count/2, ((Human, Human-agent), Body)), (Play, (Item-count/4, Man-made-object/Toy)))), (Background-view, (Sloped-terrain, Hill, Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Item/Object/Natural-object/Natural-feature/Hill,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "480601",
+    "nsd_id": "63345"
+  },
+  "shared0871_nsd63450": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Sloped-terrain, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "480990",
+    "nsd_id": "63449"
+  },
+  "shared0872_nsd63747": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Building), (Item-count/2, Clock-face), ((Item-count, High), Icon))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Media/Visualization/Image/Icon))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "429887",
+    "nsd_id": "63746"
+  },
+  "shared0873_nsd63782": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Boat), (Item-count/1, River), Rocky-terrain)), (Background-view, (Outdoors, Plant, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Boat),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River),Property/Environmental-property/Terrain/Rocky-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural))",
+    "coco_id": "429902",
+    "nsd_id": "63781"
+  },
+  "shared0874_nsd63826": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Vehicle), (Item-count/1, Word), (Item-count/1, Road))), (Background-view, (Natural-feature/Sky, Paved-terrain, Outdoors, Urban, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building))",
+    "coco_id": "561006",
+    "nsd_id": "63825"
+  },
+  "shared0875_nsd63923": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Female, (Face, Away-from), Agent-trait/Adolescent)), (Item-count/1, Building), (Item-count/1, Man-made-object))), (Background-view, (Book, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adolescent)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Document/Book,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "482858",
+    "nsd_id": "63922"
+  },
+  "shared0876_nsd63932": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/2, Boat), (Item-count/1, River))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Vehicle/Boat),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "482912",
+    "nsd_id": "63931"
+  },
+  "shared0877_nsd63945": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, (Human, Body, Female, (Face, Away-from), Agent-trait/Adult)), (Item-count/1, Furnishing), (Item-count/1, Man-made-object), (Item-count/2, Man-made-object/Toy))), (Background-view, (Composite-terrain, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "342639",
+    "nsd_id": "63944"
+  },
+  "shared0878_nsd64005": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Towards), Agent-trait/Adolescent)), (Play, (Item-count/2, Man-made-object/Toy))), (Item-count/1, Word))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "167908",
+    "nsd_id": "64004"
+  },
+  "shared0879_nsd64097": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body, Agent-trait/Adult)), (Item-count/1, Path), ((Item-count, High), Man-made-object))), (Background-view, (Outdoors, Paved-terrain, Urban, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building))",
+    "coco_id": "221441",
+    "nsd_id": "64096"
+  },
+  "shared0880_nsd64296": {
+    "hed_short": "(Foreground-view, ((Item-count/3, ((Human, Human-agent), Body)), (Play, (Item-count/3, Man-made-object)))), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "484300",
+    "nsd_id": "64295"
+  },
+  "shared0881_nsd64484": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Animal), (Item-count/1, River))), (Background-view, (Dirt-terrain, Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Dirt-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "222921",
+    "nsd_id": "64483"
+  },
+  "shared0882_nsd64499": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Man-made-object), (Item-count/1, Path))), (Background-view, (Outdoors, Plant, Composite-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Composite-terrain))",
+    "coco_id": "485113",
+    "nsd_id": "64498"
+  },
+  "shared0883_nsd64616": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Towards), Agent-trait/Adult)), (Action/Ride, (Item-count/1, (Animal, Animal-agent))), Walk), (Item-count/1, Path))), (Background-view, (Grassy-terrain, Field, Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Animal,Agent/Animal-agent))),Action/Move/Move-body-part/Move-lower-extremity/Walk),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "223447",
+    "nsd_id": "64615"
+  },
+  "shared0884_nsd64622": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Furnishing), (Item-count/2, Sculpture), (Item-count/1, Painting))), (Background-view, (Room, Indoors, Entrance))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Media/Visualization/Sculpture),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Image/Painting))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Building/Entrance))",
+    "coco_id": "485605",
+    "nsd_id": "64621"
+  },
+  "shared0885_nsd64688": {
+    "hed_short": "(Foreground-view, (((Item-count/4, ((Human, Human-agent), Body, Male, Agent-trait/Adolescent)), (Play, ((Item-count, High), Man-made-object/Toy))), (Item-count/1, (Human, Body, Male, Agent-trait/Adult)))), (Background-view, (Composite-terrain, Outdoors, Plant, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/4,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building))",
+    "coco_id": "223718",
+    "nsd_id": "64687"
+  },
+  "shared0886_nsd64772": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, Agent-trait/Child)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Outdoors, Grassy-terrain, Field, Plant, (Human, Body, Agent-trait/Child), (Human, Body, Agent-trait/Adult), Natural-feature/Sky, Man-made-object/Toy))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Child)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Biological-item/Organism/Plant,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Child),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object/Toy))",
+    "coco_id": "386856",
+    "nsd_id": "64771"
+  },
+  "shared0887_nsd64868": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Furnishing), (Item-count/1, Plant))), (Background-view, (Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "561677",
+    "nsd_id": "64867"
+  },
+  "shared0888_nsd64881": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), (Item-count/1, Man-made-object/Toy))), (Background-view, (Plant, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors))",
+    "coco_id": "486503",
+    "nsd_id": "64880"
+  },
+  "shared0889_nsd64894": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), ((Item-count, High), Ingestible-object), (Item-count/3, Man-made-object))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "224396",
+    "nsd_id": "64893"
+  },
+  "shared0890_nsd64980": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing))), (Background-view, (Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "224759",
+    "nsd_id": "64979"
+  },
+  "shared0891_nsd65011": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Building), (Item-count/1, Path))), (Background-view, ((Human, Body), Outdoors, Paved-terrain, Vehicle, Plant, Natural-feature/Sky, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Man-made-object/Vehicle,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban))",
+    "coco_id": "224869",
+    "nsd_id": "65010"
+  },
+  "shared0892_nsd65070": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), (Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Child)), ((Item-count, High), Man-made-object/Toy))), (Background-view, (Outdoors, Plant, Sloped-terrain, Natural-feature/Sky, (Human, Body), Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Child)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Sloped-terrain,Item/Object/Natural-object/Natural-feature/Sky,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Property/Environmental-property/Urban))",
+    "coco_id": "225113",
+    "nsd_id": "65069"
+  },
+  "shared0893_nsd65149": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), (Item-count/1, Word), ((Item-count, High), Character), Rocky-terrain)), (Background-view, (Path, (Human, Body, Female, Agent-trait/Adult), Plant, Natural-feature/Sky, Urban, Building, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Character),Property/Environmental-property/Terrain/Rocky-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Navigational-object/Path,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult),Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors))",
+    "coco_id": "225383",
+    "nsd_id": "65148"
+  },
+  "shared0894_nsd65188": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, River), ((Item-count, High), Plant))), (Background-view, (Composite-terrain, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "225533",
+    "nsd_id": "65187"
+  },
+  "shared0895_nsd65233": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Furnishing), (Item-count/4, Man-made-object), (Item-count/1, Desktop-computer), (Item-count/1, Keyboard), (Item-count/1, Computer-mouse), (Item-count/2, Photograph))), (Background-view, (Building, Plant, Urban, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Keyboard),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Media/Visualization/Image/Photograph))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "487825",
+    "nsd_id": "65232"
+  },
+  "shared0896_nsd65254": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Path), (Item-count/1, Furnishing), Grassy-terrain)), (Background-view, (Plant, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),Property/Environmental-property/Terrain/Grassy-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "225750",
+    "nsd_id": "65253"
+  },
+  "shared0897_nsd65268": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Furnishing), ((Item-count, High), Plant))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "430850",
+    "nsd_id": "65267"
+  },
+  "shared0898_nsd65377": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Man-made-object), (Item-count/1, Path))), (Background-view, (Car, Road, Building, Paved-terrain, Outdoors, Plant, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Vehicle/Car,Item/Object/Man-made-object/Navigational-object/Road,Item/Object/Man-made-object/Building,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Urban))",
+    "coco_id": "488406",
+    "nsd_id": "65376"
+  },
+  "shared0899_nsd65415": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Furnishing))), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "168803",
+    "nsd_id": "65414"
+  },
+  "shared0900_nsd65446": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Composite-terrain, Outdoors, Plant, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "488658",
+    "nsd_id": "65445"
+  },
+  "shared0901_nsd65640": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/1, Word))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "7567",
+    "nsd_id": "65639"
+  },
+  "shared0902_nsd65655": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/1, Runway), ((Item-count, High), Vehicle), (Item-count/1, Building))), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Runway),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "227307",
+    "nsd_id": "65654"
+  },
+  "shared0903_nsd65687": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/1, Man-made-object))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "227451",
+    "nsd_id": "65686"
+  },
+  "shared0904_nsd65770": {
+    "hed_short": "(Foreground-view, ((Item-count/2, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Outdoors, Natural-feature/Ocean))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean))",
+    "coco_id": "227733",
+    "nsd_id": "65769"
+  },
+  "shared0905_nsd65800": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/3, Man-made-object))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "227843",
+    "nsd_id": "65799"
+  },
+  "shared0906_nsd65822": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "227928",
+    "nsd_id": "65821"
+  },
+  "shared0907_nsd65873": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Ingestible-object), (Item-count/1, Furnishing)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing)))",
+    "coco_id": "228133",
+    "nsd_id": "65872"
+  },
+  "shared0908_nsd65921": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), Terrain/Sand)), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Sand)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "228316",
+    "nsd_id": "65920"
+  },
+  "shared0909_nsd65944": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), (Item-count/1, Roof), (Item-count/1, Path), (Item-count/1, Character))), (Background-view, (Urban, Natural-feature/Sky, (Human, Body), Building, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Roof),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Path),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Urban,Item/Object/Natural-object/Natural-feature/Sky,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "228380",
+    "nsd_id": "65943"
+  },
+  "shared0910_nsd66005": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Plant, Outdoors, Grassy-terrain, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Rural))",
+    "coco_id": "228565",
+    "nsd_id": "66004"
+  },
+  "shared0911_nsd66215": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Plant, Outdoors, Grassy-terrain, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Rural))",
+    "coco_id": "229456",
+    "nsd_id": "66214"
+  },
+  "shared0912_nsd66217": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Plant, Outdoors, Grassy-terrain, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Rural))",
+    "coco_id": "491611",
+    "nsd_id": "66216"
+  },
+  "shared0913_nsd66279": {
+    "hed_short": "(Foreground-view, (Item-count/4, Aircraft)), (Background-view, (Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Vehicle/Aircraft)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "356810",
+    "nsd_id": "66278"
+  },
+  "shared0914_nsd66331": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Grassy-terrain, Field, Outdoors, Plant, Rural, Animal))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural,Item/Biological-item/Organism/Animal))",
+    "coco_id": "492037",
+    "nsd_id": "66330"
+  },
+  "shared0915_nsd66343": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), ((Item-count, High), Furnishing))), (Background-view, ((Human, Body, Agent-trait/Adult), Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Property/Environmental-property/Indoors))",
+    "coco_id": "229947",
+    "nsd_id": "66342"
+  },
+  "shared0916_nsd66422": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, (Face, Away-from), Female, Agent-trait/Child)), (Item-count/1, (Human, Body, (Face, Away-from), Male, Agent-trait/Child)), (Item-count/2, (Human, Body, Female, Agent-trait/Child)), ((Item-count, High), Furnishing), ((Item-count, High), Ingestible-object))), (Background-view, (Composite-terrain, Outdoors, Building, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Child)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Child)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant))",
+    "coco_id": "38370",
+    "nsd_id": "66421"
+  },
+  "shared0917_nsd66465": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "354185",
+    "nsd_id": "66464"
+  },
+  "shared0918_nsd66480": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Man-made-object/Toy))), (Background-view, (Plant, Natural-feature/Sky, Grassy-terrain, Field, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors))",
+    "coco_id": "230422",
+    "nsd_id": "66479"
+  },
+  "shared0919_nsd66490": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/1, Plant), (Item-count/1, Entrance), ((Item-count, High), Clothing))), (Foreground-view, (Man-made-object, Room, Indoors, Drawing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Entrance),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Clothing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Item/Object/Man-made-object,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Object/Man-made-object/Media/Visualization/Image/Drawing))",
+    "coco_id": "492627",
+    "nsd_id": "66489"
+  },
+  "shared0920_nsd66581": {
+    "hed_short": "(Foreground-view, (Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Child))), (Background-view, (Paved-terrain, Building, Outdoors, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Child))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban))",
+    "coco_id": "300622",
+    "nsd_id": "66580"
+  },
+  "shared0921_nsd66644": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Furnishing), (Item-count/1, Desktop-computer), (Item-count/1, Laptop-computer), (Item-count/1, Computer-mouse), (Item-count/2, Loudspeaker))), (Background-view, (Man-made-object, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Desktop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/IO-device/Input-device/Computer-mouse),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Device/IO-device/Output-device/Auditory-device/Loudspeaker))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "231102",
+    "nsd_id": "66643"
+  },
+  "shared0922_nsd66774": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Away-from), Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))), Grassy-terrain, Field)), (Background-view, (Plant, Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "235479",
+    "nsd_id": "66773"
+  },
+  "shared0923_nsd66837": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Natural-feature/Ocean, Building, Boat, Outdoors, Natural-feature/Sky, Rocky-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Vehicle/Boat,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Terrain/Rocky-terrain))",
+    "coco_id": "231851",
+    "nsd_id": "66836"
+  },
+  "shared0924_nsd66947": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/1, Runway), (Item-count/1, Word))), (Background-view, (Outdoors, Character, Cone, Building, Natural-feature/Sky, Paved-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Runway),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Language-item/Character,Item/Object/Geometric-object/3D-shape/Cone,Item/Object/Man-made-object/Building,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Terrain/Paved-terrain))",
+    "coco_id": "232277",
+    "nsd_id": "66946"
+  },
+  "shared0925_nsd66977": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), Paved-terrain, ((Item-count, High), Furnishing))), (Background-view, (Building, Outdoors, (Human, Body), Plant, Urban, Man-made-object, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Paved-terrain,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Property/Environmental-property/Outdoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Biological-item/Organism/Plant,Property/Environmental-property/Urban,Item/Object/Man-made-object,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "494552",
+    "nsd_id": "66976"
+  },
+  "shared0926_nsd67046": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Furnishing)), (Background-view, (Entrance, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Entrance,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "232648",
+    "nsd_id": "67045"
+  },
+  "shared0927_nsd67114": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Vehicle), (Item-count/1, Building), (Item-count/2, Road))), (Background-view, (Paved-terrain, Outdoors, Plant, Natural-feature/Sky, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban))",
+    "coco_id": "495040",
+    "nsd_id": "67113"
+  },
+  "shared0928_nsd67169": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Animal)), (Background-view, (Grassy-terrain, Field, Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "233104",
+    "nsd_id": "67168"
+  },
+  "shared0929_nsd67205": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/2, Painting), (Item-count/1, Plant))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Media/Visualization/Image/Painting),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "495387",
+    "nsd_id": "67204"
+  },
+  "shared0930_nsd67238": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Ingestible-object), ((Item-count, High), Furnishing))), (Background-view, ((Human, Body, Male, Agent-trait/Adult),  Cellphone, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult),Item/Object/Man-made-object/Device/Computing-device/Cellphone,Property/Environmental-property/Indoors))",
+    "coco_id": "344729",
+    "nsd_id": "67237"
+  },
+  "shared0931_nsd67253": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, Female, (Face, Away-from), Agent-trait/Adult)), (Item-count/1, (Human, Body, Female, (Face, Away-from), Agent-trait/Older-adult)), (Item-count/1, (Human, Body)), (Item-count/1, Cellphone), (Item-count/3, Man-made-object))), (Background-view, (Paved-terrain, Laptop-computer, Outdoors, Loudspeaker, Urban, Roof, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Older-adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Cellphone),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Device/IO-device/Output-device/Auditory-device/Loudspeaker,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building/Roof,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "495568",
+    "nsd_id": "67252"
+  },
+  "shared0932_nsd67296": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, (Face, Towards), Agent-trait/Adult)), (Play, (Item-count/2, Man-made-object/Toy)))), (Background-view, (Plant, (Human, Body), Grassy-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "233580",
+    "nsd_id": "67295"
+  },
+  "shared0933_nsd67364": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Man-made-object/Toy)), (Background-view, (Outdoors, Paved-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain))",
+    "coco_id": "233873",
+    "nsd_id": "67363"
+  },
+  "shared0934_nsd67743": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Adult)), (Item-count/2, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), (Item-count/3, Man-made-object), (Item-count/3, Ingestible-object), (Item-count/3, Furnishing), (Item-count/1, Word))), (Background-view, (Natural-feature/Ocean, Natural-feature/Sky, (Human, Body, Agent-trait/Adult), Outdoors, Terrain/Sand))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Sky,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Sand))",
+    "coco_id": "497464",
+    "nsd_id": "67742"
+  },
+  "shared0935_nsd67803": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Agent-trait/Adult)), (Item-count/2, Man-made-object/Toy))), (Background-view, (Outdoors, Sloped-terrain, Natural-feature/Sky, Rural, Machine))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Sloped-terrain,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural,Item/Object/Man-made-object/Device/Machine))",
+    "coco_id": "82945",
+    "nsd_id": "67802"
+  },
+  "shared0936_nsd67830": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors, Sloped-terrain, Plant, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Sloped-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural))",
+    "coco_id": "497797",
+    "nsd_id": "67829"
+  },
+  "shared0937_nsd68024": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Animal), (Item-count/1, Vehicle), (Item-count/1, Road))), (Background-view, (Composite-terrain, Outdoors, Plant, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "498615",
+    "nsd_id": "68023"
+  },
+  "shared0938_nsd68169": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, Roof), ((Item-count, High), Plant), Grassy-terrain)), (Background-view, (Plant, Outdoors, Natural-feature/Ocean, Natural-feature/Sky, Terrain/Sand))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Roof),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),Property/Environmental-property/Terrain/Grassy-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Terrain/Sand))",
+    "coco_id": "237093",
+    "nsd_id": "68168"
+  },
+  "shared0939_nsd68279": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Furnishing), ((Item-count, High), Plant), (Item-count/1, Clock-face))), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Measurement-device/Clock/Clock-face))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "499627",
+    "nsd_id": "68278"
+  },
+  "shared0940_nsd68312": {
+    "hed_short": "(Foreground-view, ((Item-count/2, 2D-shape), (Item-count/1, Icon), (Item-count/1, Building))), (Background-view, (Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Geometric-object/2D-shape),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Image/Icon),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors))",
+    "coco_id": "499730",
+    "nsd_id": "68311"
+  },
+  "shared0941_nsd68340": {
+    "hed_short": "(Foreground-view, (Item-count/1, Furnishing)), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "237697",
+    "nsd_id": "68339"
+  },
+  "shared0942_nsd68419": {
+    "hed_short": "(Foreground-view, (((Item-count, High), (Human, Body, Agent-trait/Adult)), ((Item-count, High), Furnishing), ((Item-count, High), Word))), (Background-view, (Indoors, Room, Photograph))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Building/Room,Item/Object/Man-made-object/Media/Visualization/Image/Photograph))",
+    "coco_id": "238001",
+    "nsd_id": "68418"
+  },
+  "shared0943_nsd68472": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Grassy-terrain, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "238201",
+    "nsd_id": "68471"
+  },
+  "shared0944_nsd68742": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), Composite-terrain, ((Item-count, High), Plant))), (Background-view, (Natural-feature/Ocean, Natural-feature/Sky, (Human, Body), Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),Property/Environmental-property/Terrain/Composite-terrain,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Sky,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Property/Environmental-property/Outdoors))",
+    "coco_id": "239337",
+    "nsd_id": "68741"
+  },
+  "shared0945_nsd68815": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing))), (Background-view, (Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "501739",
+    "nsd_id": "68814"
+  },
+  "shared0946_nsd68843": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Vehicle), (Item-count/1, Roof), ((Item-count, High), Word), ((Item-count, High), Icon), (Item-count/1, Road))), (Background-view, (Natural-feature/Sky, Urban, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Roof),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Word),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Media/Visualization/Image/Icon),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Item/Object/Man-made-object/Building))",
+    "coco_id": "501867",
+    "nsd_id": "68842"
+  },
+  "shared0947_nsd68859": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Agent-trait/Adult)), ((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy))))), (Background-view, (Outdoors, Sloped-terrain, Rural, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Rural,Item/Biological-item/Organism/Plant))",
+    "coco_id": "501926",
+    "nsd_id": "68858"
+  },
+  "shared0948_nsd68898": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Away-from), Female, Agent-trait/Infant)), (Item-count/1, (Human, Body, (Face, Away-from), Male, Agent-trait/Adult)), (Item-count/1, Animal))), (Background-view, (Composite-terrain, Outdoors, Plant, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Infant)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural))",
+    "coco_id": "502058",
+    "nsd_id": "68897"
+  },
+  "shared0949_nsd69008": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object)))), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "240278",
+    "nsd_id": "69007"
+  },
+  "shared0950_nsd69026": {
+    "hed_short": "(Foreground-view, (Item-count/1, Animal)), (Background-view, (Rocky-terrain, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Rocky-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "502470",
+    "nsd_id": "69025"
+  },
+  "shared0951_nsd69031": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Composite-terrain, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "214821",
+    "nsd_id": "69030"
+  },
+  "shared0952_nsd69131": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Furnishing), (Item-count/3, Book), Indoors, (Item-count/4, Tool), (Item-count/1, Assistive-device))), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Document/Book),Property/Environmental-property/Indoors,(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Device/Tool),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "502860",
+    "nsd_id": "69130"
+  },
+  "shared0953_nsd69215": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), Field)), (Background-view, (Outdoors, Composite-terrain, Plant, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),Item/Object/Natural-object/Natural-feature/Field)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Composite-terrain,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "241026",
+    "nsd_id": "69214"
+  },
+  "shared0954_nsd69241": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/4, Man-made-object))), (Background-view, (Entrance, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Entrance,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "40187",
+    "nsd_id": "69240"
+  },
+  "shared0955_nsd69443": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/2, Path))), (Background-view, (Paved-terrain, Plant, Outdoors, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Navigational-object/Path))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building))",
+    "coco_id": "112805",
+    "nsd_id": "69442"
+  },
+  "shared0956_nsd69503": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Male, (Face, Away-from), Agent-trait/Adult)), (Item-count/1, Man-made-object))), (Background-view, (Natural-feature/Ocean, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors))",
+    "coco_id": "242133",
+    "nsd_id": "69502"
+  },
+  "shared0957_nsd69615": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, Agent-trait/Adult)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Grassy-terrain, Field, (Human, Body, Agent-trait/Adult), Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult),Property/Environmental-property/Outdoors))",
+    "coco_id": "242631",
+    "nsd_id": "69614"
+  },
+  "shared0958_nsd69617": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Animal)), (Background-view, (Grassy-terrain, Field, Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "433657",
+    "nsd_id": "69616"
+  },
+  "shared0959_nsd69786": {
+    "hed_short": "(Foreground-view, ((Item-count/2, Animal), ((Item-count, High), Plant))), (Background-view, (Composite-terrain, Outdoors, Plant, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building))",
+    "coco_id": "505486",
+    "nsd_id": "69785"
+  },
+  "shared0960_nsd69814": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), (Item-count/1, River))), (Background-view, (Grassy-terrain, Outdoors, Plant, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Natural-object/Natural-feature/River))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Rural))",
+    "coco_id": "505592",
+    "nsd_id": "69813"
+  },
+  "shared0961_nsd69832": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Female, (Face, Away-from), Agent-trait/Adolescent)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "505643",
+    "nsd_id": "69831"
+  },
+  "shared0962_nsd69840": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Book), (Item-count/2, Word), (Item-count/1, Man-made-object))), (Background-view, (Indoors, Furnishing))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Document/Book),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Furnishing))",
+    "coco_id": "505661",
+    "nsd_id": "69839"
+  },
+  "shared0963_nsd69855": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Car), ((Item-count, High), Vehicle), (Item-count/4, (Human, Body, Male, Agent-trait/Adult)), (Item-count/1, Road), ((Item-count, High), Plant))), (Background-view, (Plant, Building, Natural-feature/Sky, Urban, Man-made-object, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle/Car),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/4,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Urban,Item/Object/Man-made-object,Property/Environmental-property/Outdoors))",
+    "coco_id": "505738",
+    "nsd_id": "69854"
+  },
+  "shared0964_nsd69919": {
+    "hed_short": "(Foreground-view, (Item-count/1, (Human, Body, Female, Agent-trait/Adult))), (Background-view, ((Human, Body), Train))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,((Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Vehicle/Train))",
+    "coco_id": "243839",
+    "nsd_id": "69918"
+  },
+  "shared0965_nsd70039": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Agent-trait/Adult)), (Item-count/2, Man-made-object/Toy))), (Background-view, (Plant, Outdoors, Sloped-terrain, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Rural))",
+    "coco_id": "244334",
+    "nsd_id": "70038"
+  },
+  "shared0966_nsd70076": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Agent-trait/Infant)), (Item-count/1, Ingestible-object), (Item-count/3, Furnishing))), (Background-view, (Indoors, Room))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Infant)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors,Item/Object/Man-made-object/Building/Room))",
+    "coco_id": "244476",
+    "nsd_id": "70075"
+  },
+  "shared0967_nsd70096": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adult)), (Walk, (Item-count/3, Man-made-object/Toy)))), (Background-view, (Natural-feature/Ocean, Outdoors, Plant, Terrain/Sand))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adult)),(Action/Move/Move-body-part/Move-lower-extremity/Walk,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Ocean,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Sand))",
+    "coco_id": "244578",
+    "nsd_id": "70095"
+  },
+  "shared0968_nsd70194": {
+    "hed_short": "(Foreground-view, ((Item-count/2, (Human, Body, Male, (Face, Towards), Agent-trait/Adult)), (Item-count/2, Ingestible-object), (Item-count/1, Furnishing))), (Background-view, (Outdoors, Roof))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building/Roof))",
+    "coco_id": "244967",
+    "nsd_id": "70193"
+  },
+  "shared0969_nsd70233": {
+    "hed_short": "(Foreground-view, ((Item-count/3, (Human, Body, (Face, Away-from), Male, Agent-trait/Adult)), (Item-count/2, (Human, Body, (Face, Towards), Female, Agent-trait/Adult)), (Item-count/2, (Human, Body, Female, Agent-trait/Adult)), (Item-count/1, Road))), (Background-view, (Urban, Outdoors, Plant, Building, Paved-terrain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Urban,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building,Property/Environmental-property/Terrain/Paved-terrain))",
+    "coco_id": "434069",
+    "nsd_id": "70232"
+  },
+  "shared0970_nsd70336": {
+    "hed_short": "(Foreground-view, ((Item-count/3, Animal), ((Item-count, High), Plant))), (Background-view, (Composite-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Composite-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "507642",
+    "nsd_id": "70335"
+  },
+  "shared0971_nsd70361": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Furnishing), (Item-count/1, Entrance))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building/Entrance))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "507789",
+    "nsd_id": "70360"
+  },
+  "shared0972_nsd70369": {
+    "hed_short": "(Foreground-view, (((Item-count/1, ((Human, Human-agent), Body, Agent-trait/Adult)), (Action/Ride, (Item-count/1, Vehicle))), (Item-count/1, Road), ((Item-count, High), Word), ((Item-count, High), Character))), (Background-view, (Paved-terrain, (Human, Body), Vehicle, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Ride,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Word),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Character))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Man-made-object/Vehicle,Property/Environmental-property/Outdoors))",
+    "coco_id": "477852",
+    "nsd_id": "70368"
+  },
+  "shared0973_nsd70428": {
+    "hed_short": "(Foreground-view, (((Item-count/3, ((Human, Human-agent), Body, Male, Agent-trait/Adolescent)), (Play, (Item-count/2, Man-made-object/Toy))), ((Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adolescent)), (Play, (Item-count/1, Man-made-object/Toy))), ((Item-count, High), Word), ((Item-count, High), Character), Composite-terrain)), (Background-view, (Outdoors, Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count/3,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy))),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Word),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Language-item/Character),Property/Environmental-property/Terrain/Composite-terrain)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "245895",
+    "nsd_id": "70427"
+  },
+  "shared0974_nsd70506": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), (Item-count/1, Cellphone))), (Background-view, (Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Cellphone))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Indoors))",
+    "coco_id": "246166",
+    "nsd_id": "70505"
+  },
+  "shared0975_nsd70586": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Laptop-computer), ((Item-count, High), Furnishing))), (Background-view, (Drawing, Entrance, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Media/Visualization/Image/Drawing,Item/Object/Man-made-object/Building/Entrance,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "246453",
+    "nsd_id": "70585"
+  },
+  "shared0976_nsd70590": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Rocky-terrain, Outdoors, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Rocky-terrain,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant))",
+    "coco_id": "508612",
+    "nsd_id": "70589"
+  },
+  "shared0977_nsd70672": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Vehicle), (Item-count/1, Word), (Item-count/1, Road))), (Background-view, (Plant, Paved-terrain, Outdoors, Building))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Biological-item/Organism/Plant,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Item/Object/Man-made-object/Building))",
+    "coco_id": "246759",
+    "nsd_id": "70671"
+  },
+  "shared0978_nsd70759": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Furnishing), ((Item-count, High), Clothing))), (Background-view, (Room, Indoors, Plant, Building, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Clothing))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building,Property/Environmental-property/Urban))",
+    "coco_id": "247121",
+    "nsd_id": "70758"
+  },
+  "shared0979_nsd70765": {
+    "hed_short": "(Foreground-view, ((((Item-count, High), ((Human, Human-agent), Body, Agent-trait/Adult)), (Play, ((Item-count, High), Man-made-object))), Natural-feature/Ocean)), (Background-view, (Urban, Outdoors, Plant, Building, Mountain, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Perform/Play,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object))),Item/Object/Natural-object/Natural-feature/Ocean)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Urban,Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building,Item/Object/Natural-object/Natural-feature/Mountain,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "509292",
+    "nsd_id": "70764"
+  },
+  "shared0980_nsd70948": {
+    "hed_short": "(Foreground-view, (((Item-count, High), ((Human, Human-agent), Body)), (Play, ((Item-count, High), Man-made-object/Toy)))), (Background-view, (Sloped-terrain, (Human, Body), Plant, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body)),(Action/Perform/Play,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "247893",
+    "nsd_id": "70947"
+  },
+  "shared0981_nsd71026": {
+    "hed_short": "(Foreground-view, ((Item-count, High), Animal)), (Background-view, (Dirt-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Dirt-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "510334",
+    "nsd_id": "71025"
+  },
+  "shared0982_nsd71187": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Ingestible-object), (Item-count/1, Furnishing), (Item-count/1, (Human, Body)))), (Background-view, (Grassy-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "510900",
+    "nsd_id": "71186"
+  },
+  "shared0983_nsd71230": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Aircraft), (Item-count/1, (Human, Body, Agent-trait/Adult)), (Item-count/1, Icon))), (Background-view, (Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Aircraft),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Image/Icon))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "303637",
+    "nsd_id": "71229"
+  },
+  "shared0984_nsd71233": {
+    "hed_short": "(Foreground-view, ((((Item-count, High), ((Human, Human-agent), Body)), (Play, ((Item-count, High), Man-made-object/Toy))), (Item-count/1, Building), (Item-count/1, Machine))), (Background-view, (Sloped-terrain, (Human, Body), Plant, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body)),(Action/Perform/Play,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Building),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Machine))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "511127",
+    "nsd_id": "71232"
+  },
+  "shared0985_nsd71242": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), ((Item-count, High), Ingestible-object), ((Item-count, High), Man-made-object))), (Background-view, (Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Ingestible-object),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "511165",
+    "nsd_id": "71241"
+  },
+  "shared0986_nsd71411": {
+    "hed_short": "(Foreground-view, (Item-count/2, Vehicle)), (Background-view, (Paved-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Vehicle)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "216378",
+    "nsd_id": "71410"
+  },
+  "shared0987_nsd71451": {
+    "hed_short": "(Foreground-view, ((Item-count/3, (Human, Body, (Face, Towards), Male, Agent-trait/Adult)), ((Item-count, High), Man-made-object/Toy))), (Background-view, (Sloped-terrain, Plant, Outdoors, (Human, Body), Natural-feature/Sky, Rural, Mountain))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/3,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Male,Property/Agent-property/Agent-trait/Adult)),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body),Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural,Item/Object/Natural-object/Natural-feature/Mountain))",
+    "coco_id": "249905",
+    "nsd_id": "71450"
+  },
+  "shared0988_nsd71754": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Vehicle), (Item-count/1, Road), (Item-count/1, Character), (Item-count/3, Word))), (Background-view, (Outdoors, Paved-terrain, Urban, Car, Building, Plant))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Character),(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Urban,Item/Object/Man-made-object/Vehicle/Car,Item/Object/Man-made-object/Building,Item/Biological-item/Organism/Plant))",
+    "coco_id": "251084",
+    "nsd_id": "71753"
+  },
+  "shared0989_nsd71895": {
+    "hed_short": "(Foreground-view, ((Item-count/4, Animal), ((Item-count, High), Plant))), (Background-view, (Grassy-terrain, Plant, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/4,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "304092",
+    "nsd_id": "71894"
+  },
+  "shared0990_nsd71929": {
+    "hed_short": "(Foreground-view, ((Item-count/1, ((Human, Human-agent), Body, Male, (Face, Away-from), Agent-trait/Adolescent)), (Play, (Item-count/1, Man-made-object/Toy)))), (Background-view, (Outdoors, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Sex/Male,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Away-from),Property/Agent-property/Agent-trait/Adolescent)),(Action/Perform/Play,(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Toy)))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "251818",
+    "nsd_id": "71928"
+  },
+  "shared0991_nsd72016": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Boat), (Item-count/1, Word))), (Background-view, (Rocky-terrain, Natural-feature/Ocean, Natural-feature/Sky, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Boat),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Language-item/Word))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Rocky-terrain,Item/Object/Natural-object/Natural-feature/Ocean,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Outdoors))",
+    "coco_id": "252160",
+    "nsd_id": "72015"
+  },
+  "shared0992_nsd72081": {
+    "hed_short": "(Foreground-view, ((((Item-count, High), ((Human, Human-agent), Body, Agent-trait/Adult)), (Action/Ride, ((Item-count, High), Bicycle))), (Item-count/1, Road))), (Background-view, (Building, Vehicle, Paved-terrain, Outdoors, Urban, Man-made-object))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),((Item/Biological-item/Organism/Human,Agent/Human-agent),Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Action/Ride,((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Vehicle/Bicycle))),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Navigational-object/Road))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Building,Item/Object/Man-made-object/Vehicle,Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors,Property/Environmental-property/Urban,Item/Object/Man-made-object))",
+    "coco_id": "514563",
+    "nsd_id": "72080"
+  },
+  "shared0993_nsd72171": {
+    "hed_short": "(Foreground-view, (Item-count/3, Animal)), (Background-view, (Paved-terrain, Outdoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/3,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Paved-terrain,Property/Environmental-property/Outdoors))",
+    "coco_id": "514955",
+    "nsd_id": "72170"
+  },
+  "shared0994_nsd72210": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, (Face, Towards), Female, Agent-trait/Adult)), (Item-count/1, Assistive-device)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,(Item/Biological-item/Anatomical-item/Body-part/Head/Face,Relation/Directional-relation/Towards),Property/Agent-property/Agent-trait/Sex/Female,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Assistive-device)))",
+    "coco_id": "515102",
+    "nsd_id": "72209"
+  },
+  "shared0995_nsd72258": {
+    "hed_short": "(Foreground-view, (Item-count/2, Animal)), (Background-view, (Grassy-terrain, Field, Outdoors, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Biological-item/Organism/Animal)),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Object/Natural-object/Natural-feature/Field,Property/Environmental-property/Outdoors,Property/Environmental-property/Rural))",
+    "coco_id": "515296",
+    "nsd_id": "72257"
+  },
+  "shared0996_nsd72313": {
+    "hed_short": "(Foreground-view, ((Item-count/1, (Human, Body, Agent-trait/Adult)), (Item-count/2, Man-made-object/Toy))), (Background-view, (Sloped-terrain, Outdoors, Natural-feature/Sky, Rural, (Human, Body)))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body,Property/Agent-property/Agent-trait/Adult)),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Toy))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Sloped-terrain,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural,(Item/Biological-item/Organism/Human,Item/Biological-item/Anatomical-item/Body)))",
+    "coco_id": "515508",
+    "nsd_id": "72312"
+  },
+  "shared0997_nsd72511": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Train), ((Item-count, High), Plant))), (Background-view, (Outdoors, Plant, Natural-feature/Sky))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Vehicle/Train),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Outdoors,Item/Biological-item/Organism/Plant,Item/Object/Natural-object/Natural-feature/Sky))",
+    "coco_id": "254130",
+    "nsd_id": "72510"
+  },
+  "shared0998_nsd72606": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Animal), ((Item-count, High), Plant))), (Background-view, (Grassy-terrain, Plant, Outdoors, Natural-feature/Sky, Rural))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Biological-item/Organism/Animal),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Biological-item/Organism/Plant))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Property/Environmental-property/Terrain/Grassy-terrain,Item/Biological-item/Organism/Plant,Property/Environmental-property/Outdoors,Item/Object/Natural-object/Natural-feature/Sky,Property/Environmental-property/Rural))",
+    "coco_id": "516634",
+    "nsd_id": "72605"
+  },
+  "shared0999_nsd72720": {
+    "hed_short": "(Foreground-view, ((Item-count/1, Man-made-object), (Item-count/2, Icon))), (Background-view, (Bicycle, Furnishing, Room, Indoors))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,((Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object),(Property/Data-property/Data-value/Quantitative-value/Item-count/2,Item/Object/Man-made-object/Media/Visualization/Image/Icon))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Man-made-object/Vehicle/Bicycle,Item/Object/Man-made-object/Furnishing,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors))",
+    "coco_id": "304627",
+    "nsd_id": "72719"
+  },
+  "shared1000_nsd72949": {
+    "hed_short": "(Foreground-view, (((Item-count, High), Furnishing), (Item-count/1, Laptop-computer), ((Item-count, High), Book), (Item-count/1, Photograph))), (Background-view, (Natural-feature/Sky, Room, Indoors, Plant, Building, Urban))",
+    "hed_long": "(Property/Sensory-property/Sensory-presentation/Visual-presentation/Foreground-view,(((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Furnishing),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Device/Computing-device/Laptop-computer),((Property/Data-property/Data-value/Quantitative-value/Item-count,Property/Data-property/Data-value/Categorical-value/Categorical-level-value/High),Item/Object/Man-made-object/Document/Book),(Property/Data-property/Data-value/Quantitative-value/Item-count/1,Item/Object/Man-made-object/Media/Visualization/Image/Photograph))),(Property/Sensory-property/Sensory-presentation/Visual-presentation/Background-view,(Item/Object/Natural-object/Natural-feature/Sky,Item/Object/Man-made-object/Building/Room,Property/Environmental-property/Indoors,Item/Biological-item/Organism/Plant,Item/Object/Man-made-object/Building,Property/Environmental-property/Urban))",
+    "coco_id": "517878",
+    "nsd_id": "72948"
+  }
+}


### PR DESCRIPTION
## Summary

- Add HED (Hierarchical Event Descriptors) annotation support to the dashboard
- Display human-curated HED tags from nsd_hed_labels repository under each image
- Add schema support for LLM-generated HED annotations (via HED-bot)
- Compact UI layout with combined dropdowns and tighter metrics cards

## Changes

- **Schema**: Add `hed_annotation` field to PromptAnnotation type
- **Data**: Include human-hed.json with 1000 entries from MultimodalNeuroimagingLab/nsd_hed_labels
- **UI**: Combined Vision Model + Annotation Type dropdowns into single row
- **UI**: Compact token/performance metrics (inline display)
- **UI**: Collapsible HED Tags sections with Human/LLM badges and copy buttons
- **Sample**: Add example LLM HED annotation to image 1

## Screenshots

The dashboard now shows:
- HED Tags (Human) section under the image with copy button and source attribution
- HED Tags (LLM) section in annotation viewer with copy button and HED-bot link

## Test Plan

- [x] Build passes without errors
- [x] Human HED tags display correctly for all 1000 images
- [x] LLM HED annotation displays when present (image 1)
- [x] Copy buttons work for both sections
- [x] Collapsible sections expand/collapse correctly
- [x] Dark mode compatible